### PR TITLE
feat: associate suite-level hooks with specific tests

### DIFF
--- a/packages/library/src/__utils__/plant/PlantMetadataVisitor.ts
+++ b/packages/library/src/__utils__/plant/PlantMetadataVisitor.ts
@@ -66,9 +66,11 @@ export class PlantMetadataVisitor extends MetadataVisitor {
   }
 
   protected visitTestInvocation(metadata: TestInvocationMetadata): void {
+    this._registerLink(metadata, 'beforeAll');
     this._registerLink(metadata, 'before');
     this._registerLink(metadata, 'fn');
     this._registerLink(metadata, 'after');
+    this._registerLink(metadata, 'afterAll');
   }
 
   private _registerLink<T extends Metadata>(metadata: T, key: keyof T & string): void {

--- a/packages/library/src/metadata/__tests__/__snapshots__/integration.test.ts.snap
+++ b/packages/library/src/metadata/__tests__/__snapshots__/integration.test.ts.snap
@@ -292,6 +292,8 @@ tests_duplicate_name_js_hook_5 --> tests_duplicate_name_js_hook_5_0 : invocation
 tests_duplicate_name_js_test_4 --> tests_duplicate_name_js_test_4_0 : invocations[0]
 tests_duplicate_name_js_test_4 --> tests_duplicate_name_js_test_4_1 : invocations[1]
 tests_duplicate_name_js_test_5 --> tests_duplicate_name_js_test_5_0 : invocations[0]
+tests_duplicate_name_js_test_0_0 --> tests_duplicate_name_js_hook_1_0 : beforeAll[0]
+tests_duplicate_name_js_test_0_0 --> tests_duplicate_name_js_hook_2_0 : beforeAll[1]
 tests_duplicate_name_js_test_0_0 --> tests_duplicate_name_js_hook_0_0 : before[0]
 tests_duplicate_name_js_test_0_0 --> tests_duplicate_name_js_test_0_0_fn : fn
 tests_duplicate_name_js_test_0_0_fn --> tests_duplicate_name_js_test_0_0 : test
@@ -300,7 +302,9 @@ tests_duplicate_name_js_test_1_0 --> tests_duplicate_name_js_test_1_0_fn : fn
 tests_duplicate_name_js_test_1_0_fn --> tests_duplicate_name_js_test_1_0 : test
 tests_duplicate_name_js_test_1_1 --> tests_duplicate_name_js_hook_0_2 : before[0]
 tests_duplicate_name_js_test_1_1 --> tests_duplicate_name_js_test_1_1_fn : fn
+tests_duplicate_name_js_test_1_1 --> tests_duplicate_name_js_hook_3_0 : afterAll[0]
 tests_duplicate_name_js_test_1_1_fn --> tests_duplicate_name_js_test_1_1 : test
+tests_duplicate_name_js_test_4_0 --> tests_duplicate_name_js_hook_4_0 : beforeAll[0]
 tests_duplicate_name_js_test_4_0 --> tests_duplicate_name_js_hook_0_3 : before[0]
 tests_duplicate_name_js_test_4_0 --> tests_duplicate_name_js_test_4_0_fn : fn
 tests_duplicate_name_js_test_4_0_fn --> tests_duplicate_name_js_test_4_0 : test
@@ -309,6 +313,7 @@ tests_duplicate_name_js_test_5_0 --> tests_duplicate_name_js_test_5_0_fn : fn
 tests_duplicate_name_js_test_5_0_fn --> tests_duplicate_name_js_test_5_0 : test
 tests_duplicate_name_js_test_4_1 --> tests_duplicate_name_js_hook_0_5 : before[0]
 tests_duplicate_name_js_test_4_1 --> tests_duplicate_name_js_test_4_1_fn : fn
+tests_duplicate_name_js_test_4_1 --> tests_duplicate_name_js_hook_5_0 : afterAll[0]
 tests_duplicate_name_js_test_4_1_fn --> tests_duplicate_name_js_test_4_1 : test
 
 @enduml
@@ -359,6 +364,8 @@ tests_hook_after_all_fail_js_test_0 --> tests_hook_after_all_fail_js_test_0_0 : 
 tests_hook_after_all_fail_js_hook_2 --> tests_hook_after_all_fail_js_hook_2_0 : invocations[0]
 tests_hook_after_all_fail_js_test_0_0 --> tests_hook_after_all_fail_js_hook_0_0 : before[0]
 tests_hook_after_all_fail_js_test_0_0 --> tests_hook_after_all_fail_js_test_0_0_fn : fn
+tests_hook_after_all_fail_js_test_0_0 --> tests_hook_after_all_fail_js_hook_2_0 : afterAll[0]
+tests_hook_after_all_fail_js_test_0_0 --> tests_hook_after_all_fail_js_hook_1_0 : afterAll[1]
 tests_hook_after_all_fail_js_test_0_0_fn --> tests_hook_after_all_fail_js_test_0_0 : test
 
 @enduml
@@ -403,6 +410,7 @@ tests_hook_before_all_fail_js_hook_1 --> tests_hook_before_all_fail_js_hook_1_0 
 tests_hook_before_all_fail_js_test_0 --> tests_hook_before_all_fail_js_test_0_0 : invocations[0]
 tests_hook_before_all_fail_js_describe_1 --> tests_hook_before_all_fail_js_test_1 : children[0]
 tests_hook_before_all_fail_js_test_1 --> tests_hook_before_all_fail_js_test_1_0 : invocations[0]
+tests_hook_before_all_fail_js_test_1_0 --> tests_hook_before_all_fail_js_hook_1_0 : beforeAll[0]
 tests_hook_before_all_fail_js_test_1_0 --> tests_hook_before_all_fail_js_test_1_0_fn : fn
 tests_hook_before_all_fail_js_test_1_0_fn --> tests_hook_before_all_fail_js_test_1_0 : test
 
@@ -498,6 +506,7 @@ tests_hook_nesting_js_hook_3 --> tests_hook_nesting_js_hook_3_1 : invocations[1]
 tests_hook_nesting_js_hook_4 --> tests_hook_nesting_js_hook_4_0 : invocations[0]
 tests_hook_nesting_js_test_0 --> tests_hook_nesting_js_test_0_0 : invocations[0]
 tests_hook_nesting_js_test_1 --> tests_hook_nesting_js_test_1_0 : invocations[0]
+tests_hook_nesting_js_test_0_0 --> tests_hook_nesting_js_hook_1_0 : beforeAll[0]
 tests_hook_nesting_js_test_0_0 --> tests_hook_nesting_js_hook_0_0 : before[0]
 tests_hook_nesting_js_test_0_0 --> tests_hook_nesting_js_hook_2_0 : before[1]
 tests_hook_nesting_js_test_0_0 --> tests_hook_nesting_js_test_0_0_fn : fn
@@ -507,6 +516,7 @@ tests_hook_nesting_js_test_1_0 --> tests_hook_nesting_js_hook_0_1 : before[0]
 tests_hook_nesting_js_test_1_0 --> tests_hook_nesting_js_hook_2_1 : before[1]
 tests_hook_nesting_js_test_1_0 --> tests_hook_nesting_js_test_1_0_fn : fn
 tests_hook_nesting_js_test_1_0 --> tests_hook_nesting_js_hook_3_1 : after[0]
+tests_hook_nesting_js_test_1_0 --> tests_hook_nesting_js_hook_4_0 : afterAll[0]
 tests_hook_nesting_js_test_1_0_fn --> tests_hook_nesting_js_test_1_0 : test
 
 @enduml
@@ -720,11 +730,13 @@ tests_test_retry_js_hook_1 --> tests_test_retry_js_hook_1_0 : invocations[0]
 tests_test_retry_js_test_0 --> tests_test_retry_js_test_0_0 : invocations[0]
 tests_test_retry_js_test_0 --> tests_test_retry_js_test_0_1 : invocations[1]
 tests_test_retry_js_hook_2 --> tests_test_retry_js_hook_2_0 : invocations[0]
+tests_test_retry_js_test_0_0 --> tests_test_retry_js_hook_1_0 : beforeAll[0]
 tests_test_retry_js_test_0_0 --> tests_test_retry_js_hook_0_0 : before[0]
 tests_test_retry_js_test_0_0 --> tests_test_retry_js_test_0_0_fn : fn
 tests_test_retry_js_test_0_0_fn --> tests_test_retry_js_test_0_0 : test
 tests_test_retry_js_test_0_1 --> tests_test_retry_js_hook_0_1 : before[0]
 tests_test_retry_js_test_0_1 --> tests_test_retry_js_test_0_1_fn : fn
+tests_test_retry_js_test_0_1 --> tests_test_retry_js_hook_2_0 : afterAll[0]
 tests_test_retry_js_test_0_1_fn --> tests_test_retry_js_test_0_1 : test
 
 @enduml
@@ -836,6 +848,10 @@ tests_test_todo_js_hook_2 --> tests_test_todo_js_hook_2_0 : invocations[0]
 tests_test_todo_js_test_0 --> tests_test_todo_js_test_0_0 : invocations[0]
 tests_test_todo_js_hook_3 --> tests_test_todo_js_hook_3_0 : invocations[0]
 tests_test_todo_js_hook_4 --> tests_test_todo_js_hook_4_0 : invocations[0]
+tests_test_todo_js_test_0_0 --> tests_test_todo_js_hook_1_0 : beforeAll[0]
+tests_test_todo_js_test_0_0 --> tests_test_todo_js_hook_2_0 : beforeAll[1]
+tests_test_todo_js_test_0_0 --> tests_test_todo_js_hook_3_0 : afterAll[0]
+tests_test_todo_js_test_0_0 --> tests_test_todo_js_hook_4_0 : afterAll[1]
 
 @enduml
 "
@@ -1133,6 +1149,8 @@ tests_duplicate_name_js_hook_5 --> tests_duplicate_name_js_hook_5_0 : invocation
 tests_duplicate_name_js_test_4 --> tests_duplicate_name_js_test_4_0 : invocations[0]
 tests_duplicate_name_js_test_4 --> tests_duplicate_name_js_test_4_1 : invocations[1]
 tests_duplicate_name_js_test_5 --> tests_duplicate_name_js_test_5_0 : invocations[0]
+tests_duplicate_name_js_test_0_0 --> tests_duplicate_name_js_hook_1_0 : beforeAll[0]
+tests_duplicate_name_js_test_0_0 --> tests_duplicate_name_js_hook_2_0 : beforeAll[1]
 tests_duplicate_name_js_test_0_0 --> tests_duplicate_name_js_hook_0_0 : before[0]
 tests_duplicate_name_js_test_0_0 --> tests_duplicate_name_js_test_0_0_fn : fn
 tests_duplicate_name_js_test_0_0_fn --> tests_duplicate_name_js_test_0_0 : test
@@ -1141,7 +1159,9 @@ tests_duplicate_name_js_test_1_0 --> tests_duplicate_name_js_test_1_0_fn : fn
 tests_duplicate_name_js_test_1_0_fn --> tests_duplicate_name_js_test_1_0 : test
 tests_duplicate_name_js_test_1_1 --> tests_duplicate_name_js_hook_0_2 : before[0]
 tests_duplicate_name_js_test_1_1 --> tests_duplicate_name_js_test_1_1_fn : fn
+tests_duplicate_name_js_test_1_1 --> tests_duplicate_name_js_hook_3_0 : afterAll[0]
 tests_duplicate_name_js_test_1_1_fn --> tests_duplicate_name_js_test_1_1 : test
+tests_duplicate_name_js_test_4_0 --> tests_duplicate_name_js_hook_4_0 : beforeAll[0]
 tests_duplicate_name_js_test_4_0 --> tests_duplicate_name_js_hook_0_3 : before[0]
 tests_duplicate_name_js_test_4_0 --> tests_duplicate_name_js_test_4_0_fn : fn
 tests_duplicate_name_js_test_4_0_fn --> tests_duplicate_name_js_test_4_0 : test
@@ -1150,6 +1170,7 @@ tests_duplicate_name_js_test_5_0 --> tests_duplicate_name_js_test_5_0_fn : fn
 tests_duplicate_name_js_test_5_0_fn --> tests_duplicate_name_js_test_5_0 : test
 tests_duplicate_name_js_test_4_1 --> tests_duplicate_name_js_hook_0_5 : before[0]
 tests_duplicate_name_js_test_4_1 --> tests_duplicate_name_js_test_4_1_fn : fn
+tests_duplicate_name_js_test_4_1 --> tests_duplicate_name_js_hook_5_0 : afterAll[0]
 tests_duplicate_name_js_test_4_1_fn --> tests_duplicate_name_js_test_4_1 : test
 
 @enduml
@@ -1200,6 +1221,8 @@ tests_hook_after_all_fail_js_test_0 --> tests_hook_after_all_fail_js_test_0_0 : 
 tests_hook_after_all_fail_js_hook_2 --> tests_hook_after_all_fail_js_hook_2_0 : invocations[0]
 tests_hook_after_all_fail_js_test_0_0 --> tests_hook_after_all_fail_js_hook_0_0 : before[0]
 tests_hook_after_all_fail_js_test_0_0 --> tests_hook_after_all_fail_js_test_0_0_fn : fn
+tests_hook_after_all_fail_js_test_0_0 --> tests_hook_after_all_fail_js_hook_2_0 : afterAll[0]
+tests_hook_after_all_fail_js_test_0_0 --> tests_hook_after_all_fail_js_hook_1_0 : afterAll[1]
 tests_hook_after_all_fail_js_test_0_0_fn --> tests_hook_after_all_fail_js_test_0_0 : test
 
 @enduml
@@ -1244,6 +1267,7 @@ tests_hook_before_all_fail_js_hook_1 --> tests_hook_before_all_fail_js_hook_1_0 
 tests_hook_before_all_fail_js_test_0 --> tests_hook_before_all_fail_js_test_0_0 : invocations[0]
 tests_hook_before_all_fail_js_describe_1 --> tests_hook_before_all_fail_js_test_1 : children[0]
 tests_hook_before_all_fail_js_test_1 --> tests_hook_before_all_fail_js_test_1_0 : invocations[0]
+tests_hook_before_all_fail_js_test_1_0 --> tests_hook_before_all_fail_js_hook_1_0 : beforeAll[0]
 tests_hook_before_all_fail_js_test_1_0 --> tests_hook_before_all_fail_js_test_1_0_fn : fn
 tests_hook_before_all_fail_js_test_1_0_fn --> tests_hook_before_all_fail_js_test_1_0 : test
 
@@ -1339,6 +1363,7 @@ tests_hook_nesting_js_hook_3 --> tests_hook_nesting_js_hook_3_1 : invocations[1]
 tests_hook_nesting_js_hook_4 --> tests_hook_nesting_js_hook_4_0 : invocations[0]
 tests_hook_nesting_js_test_0 --> tests_hook_nesting_js_test_0_0 : invocations[0]
 tests_hook_nesting_js_test_1 --> tests_hook_nesting_js_test_1_0 : invocations[0]
+tests_hook_nesting_js_test_0_0 --> tests_hook_nesting_js_hook_1_0 : beforeAll[0]
 tests_hook_nesting_js_test_0_0 --> tests_hook_nesting_js_hook_0_0 : before[0]
 tests_hook_nesting_js_test_0_0 --> tests_hook_nesting_js_hook_2_0 : before[1]
 tests_hook_nesting_js_test_0_0 --> tests_hook_nesting_js_test_0_0_fn : fn
@@ -1348,6 +1373,7 @@ tests_hook_nesting_js_test_1_0 --> tests_hook_nesting_js_hook_0_1 : before[0]
 tests_hook_nesting_js_test_1_0 --> tests_hook_nesting_js_hook_2_1 : before[1]
 tests_hook_nesting_js_test_1_0 --> tests_hook_nesting_js_test_1_0_fn : fn
 tests_hook_nesting_js_test_1_0 --> tests_hook_nesting_js_hook_3_1 : after[0]
+tests_hook_nesting_js_test_1_0 --> tests_hook_nesting_js_hook_4_0 : afterAll[0]
 tests_hook_nesting_js_test_1_0_fn --> tests_hook_nesting_js_test_1_0 : test
 
 @enduml
@@ -1561,11 +1587,13 @@ tests_test_retry_js_hook_1 --> tests_test_retry_js_hook_1_0 : invocations[0]
 tests_test_retry_js_test_0 --> tests_test_retry_js_test_0_0 : invocations[0]
 tests_test_retry_js_test_0 --> tests_test_retry_js_test_0_1 : invocations[1]
 tests_test_retry_js_hook_2 --> tests_test_retry_js_hook_2_0 : invocations[0]
+tests_test_retry_js_test_0_0 --> tests_test_retry_js_hook_1_0 : beforeAll[0]
 tests_test_retry_js_test_0_0 --> tests_test_retry_js_hook_0_0 : before[0]
 tests_test_retry_js_test_0_0 --> tests_test_retry_js_test_0_0_fn : fn
 tests_test_retry_js_test_0_0_fn --> tests_test_retry_js_test_0_0 : test
 tests_test_retry_js_test_0_1 --> tests_test_retry_js_hook_0_1 : before[0]
 tests_test_retry_js_test_0_1 --> tests_test_retry_js_test_0_1_fn : fn
+tests_test_retry_js_test_0_1 --> tests_test_retry_js_hook_2_0 : afterAll[0]
 tests_test_retry_js_test_0_1_fn --> tests_test_retry_js_test_0_1 : test
 
 @enduml
@@ -1677,6 +1705,10 @@ tests_test_todo_js_hook_2 --> tests_test_todo_js_hook_2_0 : invocations[0]
 tests_test_todo_js_test_0 --> tests_test_todo_js_test_0_0 : invocations[0]
 tests_test_todo_js_hook_3 --> tests_test_todo_js_hook_3_0 : invocations[0]
 tests_test_todo_js_hook_4 --> tests_test_todo_js_hook_4_0 : invocations[0]
+tests_test_todo_js_test_0_0 --> tests_test_todo_js_hook_1_0 : beforeAll[0]
+tests_test_todo_js_test_0_0 --> tests_test_todo_js_hook_2_0 : beforeAll[1]
+tests_test_todo_js_test_0_0 --> tests_test_todo_js_hook_3_0 : afterAll[0]
+tests_test_todo_js_test_0_0 --> tests_test_todo_js_hook_4_0 : afterAll[1]
 
 @enduml
 "
@@ -2646,6 +2678,8 @@ tests_duplicate_name_js_hook_5 --> tests_duplicate_name_js_hook_5_0 : invocation
 tests_duplicate_name_js_test_4 --> tests_duplicate_name_js_test_4_0 : invocations[0]
 tests_duplicate_name_js_test_4 --> tests_duplicate_name_js_test_4_1 : invocations[1]
 tests_duplicate_name_js_test_5 --> tests_duplicate_name_js_test_5_0 : invocations[0]
+tests_duplicate_name_js_test_0_0 --> tests_duplicate_name_js_hook_1_0 : beforeAll[0]
+tests_duplicate_name_js_test_0_0 --> tests_duplicate_name_js_hook_2_0 : beforeAll[1]
 tests_duplicate_name_js_test_0_0 --> tests_duplicate_name_js_hook_0_0 : before[0]
 tests_duplicate_name_js_test_0_0 --> tests_duplicate_name_js_test_0_0_fn : fn
 tests_duplicate_name_js_test_0_0_fn --> tests_duplicate_name_js_test_0_0 : test
@@ -2654,7 +2688,9 @@ tests_duplicate_name_js_test_1_0 --> tests_duplicate_name_js_test_1_0_fn : fn
 tests_duplicate_name_js_test_1_0_fn --> tests_duplicate_name_js_test_1_0 : test
 tests_duplicate_name_js_test_1_1 --> tests_duplicate_name_js_hook_0_2 : before[0]
 tests_duplicate_name_js_test_1_1 --> tests_duplicate_name_js_test_1_1_fn : fn
+tests_duplicate_name_js_test_1_1 --> tests_duplicate_name_js_hook_3_0 : afterAll[0]
 tests_duplicate_name_js_test_1_1_fn --> tests_duplicate_name_js_test_1_1 : test
+tests_duplicate_name_js_test_4_0 --> tests_duplicate_name_js_hook_4_0 : beforeAll[0]
 tests_duplicate_name_js_test_4_0 --> tests_duplicate_name_js_hook_0_3 : before[0]
 tests_duplicate_name_js_test_4_0 --> tests_duplicate_name_js_test_4_0_fn : fn
 tests_duplicate_name_js_test_4_0_fn --> tests_duplicate_name_js_test_4_0 : test
@@ -2663,6 +2699,7 @@ tests_duplicate_name_js_test_5_0 --> tests_duplicate_name_js_test_5_0_fn : fn
 tests_duplicate_name_js_test_5_0_fn --> tests_duplicate_name_js_test_5_0 : test
 tests_duplicate_name_js_test_4_1 --> tests_duplicate_name_js_hook_0_5 : before[0]
 tests_duplicate_name_js_test_4_1 --> tests_duplicate_name_js_test_4_1_fn : fn
+tests_duplicate_name_js_test_4_1 --> tests_duplicate_name_js_hook_5_0 : afterAll[0]
 tests_duplicate_name_js_test_4_1_fn --> tests_duplicate_name_js_test_4_1 : test
 
 @enduml
@@ -2713,6 +2750,8 @@ tests_hook_after_all_fail_js_test_0 --> tests_hook_after_all_fail_js_test_0_0 : 
 tests_hook_after_all_fail_js_hook_2 --> tests_hook_after_all_fail_js_hook_2_0 : invocations[0]
 tests_hook_after_all_fail_js_test_0_0 --> tests_hook_after_all_fail_js_hook_0_0 : before[0]
 tests_hook_after_all_fail_js_test_0_0 --> tests_hook_after_all_fail_js_test_0_0_fn : fn
+tests_hook_after_all_fail_js_test_0_0 --> tests_hook_after_all_fail_js_hook_2_0 : afterAll[0]
+tests_hook_after_all_fail_js_test_0_0 --> tests_hook_after_all_fail_js_hook_1_0 : afterAll[1]
 tests_hook_after_all_fail_js_test_0_0_fn --> tests_hook_after_all_fail_js_test_0_0 : test
 
 @enduml
@@ -2757,6 +2796,7 @@ tests_hook_before_all_fail_js_hook_1 --> tests_hook_before_all_fail_js_hook_1_0 
 tests_hook_before_all_fail_js_test_0 --> tests_hook_before_all_fail_js_test_0_0 : invocations[0]
 tests_hook_before_all_fail_js_describe_1 --> tests_hook_before_all_fail_js_test_1 : children[0]
 tests_hook_before_all_fail_js_test_1 --> tests_hook_before_all_fail_js_test_1_0 : invocations[0]
+tests_hook_before_all_fail_js_test_1_0 --> tests_hook_before_all_fail_js_hook_1_0 : beforeAll[0]
 tests_hook_before_all_fail_js_test_1_0 --> tests_hook_before_all_fail_js_test_1_0_fn : fn
 tests_hook_before_all_fail_js_test_1_0_fn --> tests_hook_before_all_fail_js_test_1_0 : test
 
@@ -2852,6 +2892,7 @@ tests_hook_nesting_js_hook_3 --> tests_hook_nesting_js_hook_3_1 : invocations[1]
 tests_hook_nesting_js_hook_4 --> tests_hook_nesting_js_hook_4_0 : invocations[0]
 tests_hook_nesting_js_test_0 --> tests_hook_nesting_js_test_0_0 : invocations[0]
 tests_hook_nesting_js_test_1 --> tests_hook_nesting_js_test_1_0 : invocations[0]
+tests_hook_nesting_js_test_0_0 --> tests_hook_nesting_js_hook_1_0 : beforeAll[0]
 tests_hook_nesting_js_test_0_0 --> tests_hook_nesting_js_hook_0_0 : before[0]
 tests_hook_nesting_js_test_0_0 --> tests_hook_nesting_js_hook_2_0 : before[1]
 tests_hook_nesting_js_test_0_0 --> tests_hook_nesting_js_test_0_0_fn : fn
@@ -2861,6 +2902,7 @@ tests_hook_nesting_js_test_1_0 --> tests_hook_nesting_js_hook_0_1 : before[0]
 tests_hook_nesting_js_test_1_0 --> tests_hook_nesting_js_hook_2_1 : before[1]
 tests_hook_nesting_js_test_1_0 --> tests_hook_nesting_js_test_1_0_fn : fn
 tests_hook_nesting_js_test_1_0 --> tests_hook_nesting_js_hook_3_1 : after[0]
+tests_hook_nesting_js_test_1_0 --> tests_hook_nesting_js_hook_4_0 : afterAll[0]
 tests_hook_nesting_js_test_1_0_fn --> tests_hook_nesting_js_test_1_0 : test
 
 @enduml
@@ -3054,11 +3096,13 @@ tests_test_retry_js_hook_1 --> tests_test_retry_js_hook_1_0 : invocations[0]
 tests_test_retry_js_test_0 --> tests_test_retry_js_test_0_0 : invocations[0]
 tests_test_retry_js_test_0 --> tests_test_retry_js_test_0_1 : invocations[1]
 tests_test_retry_js_hook_2 --> tests_test_retry_js_hook_2_0 : invocations[0]
+tests_test_retry_js_test_0_0 --> tests_test_retry_js_hook_1_0 : beforeAll[0]
 tests_test_retry_js_test_0_0 --> tests_test_retry_js_hook_0_0 : before[0]
 tests_test_retry_js_test_0_0 --> tests_test_retry_js_test_0_0_fn : fn
 tests_test_retry_js_test_0_0_fn --> tests_test_retry_js_test_0_0 : test
 tests_test_retry_js_test_0_1 --> tests_test_retry_js_hook_0_1 : before[0]
 tests_test_retry_js_test_0_1 --> tests_test_retry_js_test_0_1_fn : fn
+tests_test_retry_js_test_0_1 --> tests_test_retry_js_hook_2_0 : afterAll[0]
 tests_test_retry_js_test_0_1_fn --> tests_test_retry_js_test_0_1 : test
 
 @enduml
@@ -3170,6 +3214,10 @@ tests_test_todo_js_hook_2 --> tests_test_todo_js_hook_2_0 : invocations[0]
 tests_test_todo_js_test_0 --> tests_test_todo_js_test_0_0 : invocations[0]
 tests_test_todo_js_hook_3 --> tests_test_todo_js_hook_3_0 : invocations[0]
 tests_test_todo_js_hook_4 --> tests_test_todo_js_hook_4_0 : invocations[0]
+tests_test_todo_js_test_0_0 --> tests_test_todo_js_hook_1_0 : beforeAll[0]
+tests_test_todo_js_test_0_0 --> tests_test_todo_js_hook_2_0 : beforeAll[1]
+tests_test_todo_js_test_0_0 --> tests_test_todo_js_hook_3_0 : afterAll[0]
+tests_test_todo_js_test_0_0 --> tests_test_todo_js_hook_4_0 : afterAll[1]
 
 @enduml
 "
@@ -3467,6 +3515,8 @@ tests_duplicate_name_js_hook_5 --> tests_duplicate_name_js_hook_5_0 : invocation
 tests_duplicate_name_js_test_4 --> tests_duplicate_name_js_test_4_0 : invocations[0]
 tests_duplicate_name_js_test_4 --> tests_duplicate_name_js_test_4_1 : invocations[1]
 tests_duplicate_name_js_test_5 --> tests_duplicate_name_js_test_5_0 : invocations[0]
+tests_duplicate_name_js_test_0_0 --> tests_duplicate_name_js_hook_1_0 : beforeAll[0]
+tests_duplicate_name_js_test_0_0 --> tests_duplicate_name_js_hook_2_0 : beforeAll[1]
 tests_duplicate_name_js_test_0_0 --> tests_duplicate_name_js_hook_0_0 : before[0]
 tests_duplicate_name_js_test_0_0 --> tests_duplicate_name_js_test_0_0_fn : fn
 tests_duplicate_name_js_test_0_0_fn --> tests_duplicate_name_js_test_0_0 : test
@@ -3475,7 +3525,9 @@ tests_duplicate_name_js_test_1_0 --> tests_duplicate_name_js_test_1_0_fn : fn
 tests_duplicate_name_js_test_1_0_fn --> tests_duplicate_name_js_test_1_0 : test
 tests_duplicate_name_js_test_1_1 --> tests_duplicate_name_js_hook_0_2 : before[0]
 tests_duplicate_name_js_test_1_1 --> tests_duplicate_name_js_test_1_1_fn : fn
+tests_duplicate_name_js_test_1_1 --> tests_duplicate_name_js_hook_3_0 : afterAll[0]
 tests_duplicate_name_js_test_1_1_fn --> tests_duplicate_name_js_test_1_1 : test
+tests_duplicate_name_js_test_4_0 --> tests_duplicate_name_js_hook_4_0 : beforeAll[0]
 tests_duplicate_name_js_test_4_0 --> tests_duplicate_name_js_hook_0_3 : before[0]
 tests_duplicate_name_js_test_4_0 --> tests_duplicate_name_js_test_4_0_fn : fn
 tests_duplicate_name_js_test_4_0_fn --> tests_duplicate_name_js_test_4_0 : test
@@ -3484,6 +3536,7 @@ tests_duplicate_name_js_test_5_0 --> tests_duplicate_name_js_test_5_0_fn : fn
 tests_duplicate_name_js_test_5_0_fn --> tests_duplicate_name_js_test_5_0 : test
 tests_duplicate_name_js_test_4_1 --> tests_duplicate_name_js_hook_0_5 : before[0]
 tests_duplicate_name_js_test_4_1 --> tests_duplicate_name_js_test_4_1_fn : fn
+tests_duplicate_name_js_test_4_1 --> tests_duplicate_name_js_hook_5_0 : afterAll[0]
 tests_duplicate_name_js_test_4_1_fn --> tests_duplicate_name_js_test_4_1 : test
 
 @enduml
@@ -3534,6 +3587,8 @@ tests_hook_after_all_fail_js_test_0 --> tests_hook_after_all_fail_js_test_0_0 : 
 tests_hook_after_all_fail_js_hook_2 --> tests_hook_after_all_fail_js_hook_2_0 : invocations[0]
 tests_hook_after_all_fail_js_test_0_0 --> tests_hook_after_all_fail_js_hook_0_0 : before[0]
 tests_hook_after_all_fail_js_test_0_0 --> tests_hook_after_all_fail_js_test_0_0_fn : fn
+tests_hook_after_all_fail_js_test_0_0 --> tests_hook_after_all_fail_js_hook_2_0 : afterAll[0]
+tests_hook_after_all_fail_js_test_0_0 --> tests_hook_after_all_fail_js_hook_1_0 : afterAll[1]
 tests_hook_after_all_fail_js_test_0_0_fn --> tests_hook_after_all_fail_js_test_0_0 : test
 
 @enduml
@@ -3578,6 +3633,7 @@ tests_hook_before_all_fail_js_hook_1 --> tests_hook_before_all_fail_js_hook_1_0 
 tests_hook_before_all_fail_js_test_0 --> tests_hook_before_all_fail_js_test_0_0 : invocations[0]
 tests_hook_before_all_fail_js_describe_1 --> tests_hook_before_all_fail_js_test_1 : children[0]
 tests_hook_before_all_fail_js_test_1 --> tests_hook_before_all_fail_js_test_1_0 : invocations[0]
+tests_hook_before_all_fail_js_test_1_0 --> tests_hook_before_all_fail_js_hook_1_0 : beforeAll[0]
 tests_hook_before_all_fail_js_test_1_0 --> tests_hook_before_all_fail_js_test_1_0_fn : fn
 tests_hook_before_all_fail_js_test_1_0_fn --> tests_hook_before_all_fail_js_test_1_0 : test
 
@@ -3673,6 +3729,7 @@ tests_hook_nesting_js_hook_3 --> tests_hook_nesting_js_hook_3_1 : invocations[1]
 tests_hook_nesting_js_hook_4 --> tests_hook_nesting_js_hook_4_0 : invocations[0]
 tests_hook_nesting_js_test_0 --> tests_hook_nesting_js_test_0_0 : invocations[0]
 tests_hook_nesting_js_test_1 --> tests_hook_nesting_js_test_1_0 : invocations[0]
+tests_hook_nesting_js_test_0_0 --> tests_hook_nesting_js_hook_1_0 : beforeAll[0]
 tests_hook_nesting_js_test_0_0 --> tests_hook_nesting_js_hook_0_0 : before[0]
 tests_hook_nesting_js_test_0_0 --> tests_hook_nesting_js_hook_2_0 : before[1]
 tests_hook_nesting_js_test_0_0 --> tests_hook_nesting_js_test_0_0_fn : fn
@@ -3682,6 +3739,7 @@ tests_hook_nesting_js_test_1_0 --> tests_hook_nesting_js_hook_0_1 : before[0]
 tests_hook_nesting_js_test_1_0 --> tests_hook_nesting_js_hook_2_1 : before[1]
 tests_hook_nesting_js_test_1_0 --> tests_hook_nesting_js_test_1_0_fn : fn
 tests_hook_nesting_js_test_1_0 --> tests_hook_nesting_js_hook_3_1 : after[0]
+tests_hook_nesting_js_test_1_0 --> tests_hook_nesting_js_hook_4_0 : afterAll[0]
 tests_hook_nesting_js_test_1_0_fn --> tests_hook_nesting_js_test_1_0 : test
 
 @enduml
@@ -3875,11 +3933,13 @@ tests_test_retry_js_hook_1 --> tests_test_retry_js_hook_1_0 : invocations[0]
 tests_test_retry_js_test_0 --> tests_test_retry_js_test_0_0 : invocations[0]
 tests_test_retry_js_test_0 --> tests_test_retry_js_test_0_1 : invocations[1]
 tests_test_retry_js_hook_2 --> tests_test_retry_js_hook_2_0 : invocations[0]
+tests_test_retry_js_test_0_0 --> tests_test_retry_js_hook_1_0 : beforeAll[0]
 tests_test_retry_js_test_0_0 --> tests_test_retry_js_hook_0_0 : before[0]
 tests_test_retry_js_test_0_0 --> tests_test_retry_js_test_0_0_fn : fn
 tests_test_retry_js_test_0_0_fn --> tests_test_retry_js_test_0_0 : test
 tests_test_retry_js_test_0_1 --> tests_test_retry_js_hook_0_1 : before[0]
 tests_test_retry_js_test_0_1 --> tests_test_retry_js_test_0_1_fn : fn
+tests_test_retry_js_test_0_1 --> tests_test_retry_js_hook_2_0 : afterAll[0]
 tests_test_retry_js_test_0_1_fn --> tests_test_retry_js_test_0_1 : test
 
 @enduml
@@ -3991,6 +4051,10 @@ tests_test_todo_js_hook_2 --> tests_test_todo_js_hook_2_0 : invocations[0]
 tests_test_todo_js_test_0 --> tests_test_todo_js_test_0_0 : invocations[0]
 tests_test_todo_js_hook_3 --> tests_test_todo_js_hook_3_0 : invocations[0]
 tests_test_todo_js_hook_4 --> tests_test_todo_js_hook_4_0 : invocations[0]
+tests_test_todo_js_test_0_0 --> tests_test_todo_js_hook_1_0 : beforeAll[0]
+tests_test_todo_js_test_0_0 --> tests_test_todo_js_hook_2_0 : beforeAll[1]
+tests_test_todo_js_test_0_0 --> tests_test_todo_js_hook_3_0 : afterAll[0]
+tests_test_todo_js_test_0_0 --> tests_test_todo_js_hook_4_0 : afterAll[1]
 
 @enduml
 "
@@ -4960,6 +5024,8 @@ tests_duplicate_name_js_hook_5 --> tests_duplicate_name_js_hook_5_0 : invocation
 tests_duplicate_name_js_test_4 --> tests_duplicate_name_js_test_4_0 : invocations[0]
 tests_duplicate_name_js_test_4 --> tests_duplicate_name_js_test_4_1 : invocations[1]
 tests_duplicate_name_js_test_5 --> tests_duplicate_name_js_test_5_0 : invocations[0]
+tests_duplicate_name_js_test_0_0 --> tests_duplicate_name_js_hook_1_0 : beforeAll[0]
+tests_duplicate_name_js_test_0_0 --> tests_duplicate_name_js_hook_2_0 : beforeAll[1]
 tests_duplicate_name_js_test_0_0 --> tests_duplicate_name_js_hook_0_0 : before[0]
 tests_duplicate_name_js_test_0_0 --> tests_duplicate_name_js_test_0_0_fn : fn
 tests_duplicate_name_js_test_0_0_fn --> tests_duplicate_name_js_test_0_0 : test
@@ -4968,7 +5034,9 @@ tests_duplicate_name_js_test_1_0 --> tests_duplicate_name_js_test_1_0_fn : fn
 tests_duplicate_name_js_test_1_0_fn --> tests_duplicate_name_js_test_1_0 : test
 tests_duplicate_name_js_test_1_1 --> tests_duplicate_name_js_hook_0_2 : before[0]
 tests_duplicate_name_js_test_1_1 --> tests_duplicate_name_js_test_1_1_fn : fn
+tests_duplicate_name_js_test_1_1 --> tests_duplicate_name_js_hook_3_0 : afterAll[0]
 tests_duplicate_name_js_test_1_1_fn --> tests_duplicate_name_js_test_1_1 : test
+tests_duplicate_name_js_test_4_0 --> tests_duplicate_name_js_hook_4_0 : beforeAll[0]
 tests_duplicate_name_js_test_4_0 --> tests_duplicate_name_js_hook_0_3 : before[0]
 tests_duplicate_name_js_test_4_0 --> tests_duplicate_name_js_test_4_0_fn : fn
 tests_duplicate_name_js_test_4_0_fn --> tests_duplicate_name_js_test_4_0 : test
@@ -4977,6 +5045,7 @@ tests_duplicate_name_js_test_5_0 --> tests_duplicate_name_js_test_5_0_fn : fn
 tests_duplicate_name_js_test_5_0_fn --> tests_duplicate_name_js_test_5_0 : test
 tests_duplicate_name_js_test_4_1 --> tests_duplicate_name_js_hook_0_5 : before[0]
 tests_duplicate_name_js_test_4_1 --> tests_duplicate_name_js_test_4_1_fn : fn
+tests_duplicate_name_js_test_4_1 --> tests_duplicate_name_js_hook_5_0 : afterAll[0]
 tests_duplicate_name_js_test_4_1_fn --> tests_duplicate_name_js_test_4_1 : test
 
 @enduml
@@ -5027,6 +5096,8 @@ tests_hook_after_all_fail_js_test_0 --> tests_hook_after_all_fail_js_test_0_0 : 
 tests_hook_after_all_fail_js_hook_2 --> tests_hook_after_all_fail_js_hook_2_0 : invocations[0]
 tests_hook_after_all_fail_js_test_0_0 --> tests_hook_after_all_fail_js_hook_0_0 : before[0]
 tests_hook_after_all_fail_js_test_0_0 --> tests_hook_after_all_fail_js_test_0_0_fn : fn
+tests_hook_after_all_fail_js_test_0_0 --> tests_hook_after_all_fail_js_hook_2_0 : afterAll[0]
+tests_hook_after_all_fail_js_test_0_0 --> tests_hook_after_all_fail_js_hook_1_0 : afterAll[1]
 tests_hook_after_all_fail_js_test_0_0_fn --> tests_hook_after_all_fail_js_test_0_0 : test
 
 @enduml
@@ -5071,6 +5142,7 @@ tests_hook_before_all_fail_js_hook_1 --> tests_hook_before_all_fail_js_hook_1_0 
 tests_hook_before_all_fail_js_test_0 --> tests_hook_before_all_fail_js_test_0_0 : invocations[0]
 tests_hook_before_all_fail_js_describe_1 --> tests_hook_before_all_fail_js_test_1 : children[0]
 tests_hook_before_all_fail_js_test_1 --> tests_hook_before_all_fail_js_test_1_0 : invocations[0]
+tests_hook_before_all_fail_js_test_1_0 --> tests_hook_before_all_fail_js_hook_1_0 : beforeAll[0]
 tests_hook_before_all_fail_js_test_1_0 --> tests_hook_before_all_fail_js_test_1_0_fn : fn
 tests_hook_before_all_fail_js_test_1_0_fn --> tests_hook_before_all_fail_js_test_1_0 : test
 
@@ -5166,6 +5238,7 @@ tests_hook_nesting_js_hook_3 --> tests_hook_nesting_js_hook_3_1 : invocations[1]
 tests_hook_nesting_js_hook_4 --> tests_hook_nesting_js_hook_4_0 : invocations[0]
 tests_hook_nesting_js_test_0 --> tests_hook_nesting_js_test_0_0 : invocations[0]
 tests_hook_nesting_js_test_1 --> tests_hook_nesting_js_test_1_0 : invocations[0]
+tests_hook_nesting_js_test_0_0 --> tests_hook_nesting_js_hook_1_0 : beforeAll[0]
 tests_hook_nesting_js_test_0_0 --> tests_hook_nesting_js_hook_0_0 : before[0]
 tests_hook_nesting_js_test_0_0 --> tests_hook_nesting_js_hook_2_0 : before[1]
 tests_hook_nesting_js_test_0_0 --> tests_hook_nesting_js_test_0_0_fn : fn
@@ -5175,6 +5248,7 @@ tests_hook_nesting_js_test_1_0 --> tests_hook_nesting_js_hook_0_1 : before[0]
 tests_hook_nesting_js_test_1_0 --> tests_hook_nesting_js_hook_2_1 : before[1]
 tests_hook_nesting_js_test_1_0 --> tests_hook_nesting_js_test_1_0_fn : fn
 tests_hook_nesting_js_test_1_0 --> tests_hook_nesting_js_hook_3_1 : after[0]
+tests_hook_nesting_js_test_1_0 --> tests_hook_nesting_js_hook_4_0 : afterAll[0]
 tests_hook_nesting_js_test_1_0_fn --> tests_hook_nesting_js_test_1_0 : test
 
 @enduml
@@ -5368,11 +5442,13 @@ tests_test_retry_js_hook_1 --> tests_test_retry_js_hook_1_0 : invocations[0]
 tests_test_retry_js_test_0 --> tests_test_retry_js_test_0_0 : invocations[0]
 tests_test_retry_js_test_0 --> tests_test_retry_js_test_0_1 : invocations[1]
 tests_test_retry_js_hook_2 --> tests_test_retry_js_hook_2_0 : invocations[0]
+tests_test_retry_js_test_0_0 --> tests_test_retry_js_hook_1_0 : beforeAll[0]
 tests_test_retry_js_test_0_0 --> tests_test_retry_js_hook_0_0 : before[0]
 tests_test_retry_js_test_0_0 --> tests_test_retry_js_test_0_0_fn : fn
 tests_test_retry_js_test_0_0_fn --> tests_test_retry_js_test_0_0 : test
 tests_test_retry_js_test_0_1 --> tests_test_retry_js_hook_0_1 : before[0]
 tests_test_retry_js_test_0_1 --> tests_test_retry_js_test_0_1_fn : fn
+tests_test_retry_js_test_0_1 --> tests_test_retry_js_hook_2_0 : afterAll[0]
 tests_test_retry_js_test_0_1_fn --> tests_test_retry_js_test_0_1 : test
 
 @enduml
@@ -5484,6 +5560,10 @@ tests_test_todo_js_hook_2 --> tests_test_todo_js_hook_2_0 : invocations[0]
 tests_test_todo_js_test_0 --> tests_test_todo_js_test_0_0 : invocations[0]
 tests_test_todo_js_hook_3 --> tests_test_todo_js_hook_3_0 : invocations[0]
 tests_test_todo_js_hook_4 --> tests_test_todo_js_hook_4_0 : invocations[0]
+tests_test_todo_js_test_0_0 --> tests_test_todo_js_hook_1_0 : beforeAll[0]
+tests_test_todo_js_test_0_0 --> tests_test_todo_js_hook_2_0 : beforeAll[1]
+tests_test_todo_js_test_0_0 --> tests_test_todo_js_hook_3_0 : afterAll[0]
+tests_test_todo_js_test_0_0 --> tests_test_todo_js_hook_4_0 : afterAll[1]
 
 @enduml
 "
@@ -5781,6 +5861,8 @@ tests_duplicate_name_js_hook_5 --> tests_duplicate_name_js_hook_5_0 : invocation
 tests_duplicate_name_js_test_4 --> tests_duplicate_name_js_test_4_0 : invocations[0]
 tests_duplicate_name_js_test_4 --> tests_duplicate_name_js_test_4_1 : invocations[1]
 tests_duplicate_name_js_test_5 --> tests_duplicate_name_js_test_5_0 : invocations[0]
+tests_duplicate_name_js_test_0_0 --> tests_duplicate_name_js_hook_1_0 : beforeAll[0]
+tests_duplicate_name_js_test_0_0 --> tests_duplicate_name_js_hook_2_0 : beforeAll[1]
 tests_duplicate_name_js_test_0_0 --> tests_duplicate_name_js_hook_0_0 : before[0]
 tests_duplicate_name_js_test_0_0 --> tests_duplicate_name_js_test_0_0_fn : fn
 tests_duplicate_name_js_test_0_0_fn --> tests_duplicate_name_js_test_0_0 : test
@@ -5789,7 +5871,9 @@ tests_duplicate_name_js_test_1_0 --> tests_duplicate_name_js_test_1_0_fn : fn
 tests_duplicate_name_js_test_1_0_fn --> tests_duplicate_name_js_test_1_0 : test
 tests_duplicate_name_js_test_1_1 --> tests_duplicate_name_js_hook_0_2 : before[0]
 tests_duplicate_name_js_test_1_1 --> tests_duplicate_name_js_test_1_1_fn : fn
+tests_duplicate_name_js_test_1_1 --> tests_duplicate_name_js_hook_3_0 : afterAll[0]
 tests_duplicate_name_js_test_1_1_fn --> tests_duplicate_name_js_test_1_1 : test
+tests_duplicate_name_js_test_4_0 --> tests_duplicate_name_js_hook_4_0 : beforeAll[0]
 tests_duplicate_name_js_test_4_0 --> tests_duplicate_name_js_hook_0_3 : before[0]
 tests_duplicate_name_js_test_4_0 --> tests_duplicate_name_js_test_4_0_fn : fn
 tests_duplicate_name_js_test_4_0_fn --> tests_duplicate_name_js_test_4_0 : test
@@ -5798,6 +5882,7 @@ tests_duplicate_name_js_test_5_0 --> tests_duplicate_name_js_test_5_0_fn : fn
 tests_duplicate_name_js_test_5_0_fn --> tests_duplicate_name_js_test_5_0 : test
 tests_duplicate_name_js_test_4_1 --> tests_duplicate_name_js_hook_0_5 : before[0]
 tests_duplicate_name_js_test_4_1 --> tests_duplicate_name_js_test_4_1_fn : fn
+tests_duplicate_name_js_test_4_1 --> tests_duplicate_name_js_hook_5_0 : afterAll[0]
 tests_duplicate_name_js_test_4_1_fn --> tests_duplicate_name_js_test_4_1 : test
 
 @enduml
@@ -5848,6 +5933,8 @@ tests_hook_after_all_fail_js_test_0 --> tests_hook_after_all_fail_js_test_0_0 : 
 tests_hook_after_all_fail_js_hook_2 --> tests_hook_after_all_fail_js_hook_2_0 : invocations[0]
 tests_hook_after_all_fail_js_test_0_0 --> tests_hook_after_all_fail_js_hook_0_0 : before[0]
 tests_hook_after_all_fail_js_test_0_0 --> tests_hook_after_all_fail_js_test_0_0_fn : fn
+tests_hook_after_all_fail_js_test_0_0 --> tests_hook_after_all_fail_js_hook_2_0 : afterAll[0]
+tests_hook_after_all_fail_js_test_0_0 --> tests_hook_after_all_fail_js_hook_1_0 : afterAll[1]
 tests_hook_after_all_fail_js_test_0_0_fn --> tests_hook_after_all_fail_js_test_0_0 : test
 
 @enduml
@@ -5892,6 +5979,7 @@ tests_hook_before_all_fail_js_hook_1 --> tests_hook_before_all_fail_js_hook_1_0 
 tests_hook_before_all_fail_js_test_0 --> tests_hook_before_all_fail_js_test_0_0 : invocations[0]
 tests_hook_before_all_fail_js_describe_1 --> tests_hook_before_all_fail_js_test_1 : children[0]
 tests_hook_before_all_fail_js_test_1 --> tests_hook_before_all_fail_js_test_1_0 : invocations[0]
+tests_hook_before_all_fail_js_test_1_0 --> tests_hook_before_all_fail_js_hook_1_0 : beforeAll[0]
 tests_hook_before_all_fail_js_test_1_0 --> tests_hook_before_all_fail_js_test_1_0_fn : fn
 tests_hook_before_all_fail_js_test_1_0_fn --> tests_hook_before_all_fail_js_test_1_0 : test
 
@@ -5987,6 +6075,7 @@ tests_hook_nesting_js_hook_3 --> tests_hook_nesting_js_hook_3_1 : invocations[1]
 tests_hook_nesting_js_hook_4 --> tests_hook_nesting_js_hook_4_0 : invocations[0]
 tests_hook_nesting_js_test_0 --> tests_hook_nesting_js_test_0_0 : invocations[0]
 tests_hook_nesting_js_test_1 --> tests_hook_nesting_js_test_1_0 : invocations[0]
+tests_hook_nesting_js_test_0_0 --> tests_hook_nesting_js_hook_1_0 : beforeAll[0]
 tests_hook_nesting_js_test_0_0 --> tests_hook_nesting_js_hook_0_0 : before[0]
 tests_hook_nesting_js_test_0_0 --> tests_hook_nesting_js_hook_2_0 : before[1]
 tests_hook_nesting_js_test_0_0 --> tests_hook_nesting_js_test_0_0_fn : fn
@@ -5996,6 +6085,7 @@ tests_hook_nesting_js_test_1_0 --> tests_hook_nesting_js_hook_0_1 : before[0]
 tests_hook_nesting_js_test_1_0 --> tests_hook_nesting_js_hook_2_1 : before[1]
 tests_hook_nesting_js_test_1_0 --> tests_hook_nesting_js_test_1_0_fn : fn
 tests_hook_nesting_js_test_1_0 --> tests_hook_nesting_js_hook_3_1 : after[0]
+tests_hook_nesting_js_test_1_0 --> tests_hook_nesting_js_hook_4_0 : afterAll[0]
 tests_hook_nesting_js_test_1_0_fn --> tests_hook_nesting_js_test_1_0 : test
 
 @enduml
@@ -6189,11 +6279,13 @@ tests_test_retry_js_hook_1 --> tests_test_retry_js_hook_1_0 : invocations[0]
 tests_test_retry_js_test_0 --> tests_test_retry_js_test_0_0 : invocations[0]
 tests_test_retry_js_test_0 --> tests_test_retry_js_test_0_1 : invocations[1]
 tests_test_retry_js_hook_2 --> tests_test_retry_js_hook_2_0 : invocations[0]
+tests_test_retry_js_test_0_0 --> tests_test_retry_js_hook_1_0 : beforeAll[0]
 tests_test_retry_js_test_0_0 --> tests_test_retry_js_hook_0_0 : before[0]
 tests_test_retry_js_test_0_0 --> tests_test_retry_js_test_0_0_fn : fn
 tests_test_retry_js_test_0_0_fn --> tests_test_retry_js_test_0_0 : test
 tests_test_retry_js_test_0_1 --> tests_test_retry_js_hook_0_1 : before[0]
 tests_test_retry_js_test_0_1 --> tests_test_retry_js_test_0_1_fn : fn
+tests_test_retry_js_test_0_1 --> tests_test_retry_js_hook_2_0 : afterAll[0]
 tests_test_retry_js_test_0_1_fn --> tests_test_retry_js_test_0_1 : test
 
 @enduml
@@ -6305,6 +6397,10 @@ tests_test_todo_js_hook_2 --> tests_test_todo_js_hook_2_0 : invocations[0]
 tests_test_todo_js_test_0 --> tests_test_todo_js_test_0_0 : invocations[0]
 tests_test_todo_js_hook_3 --> tests_test_todo_js_hook_3_0 : invocations[0]
 tests_test_todo_js_hook_4 --> tests_test_todo_js_hook_4_0 : invocations[0]
+tests_test_todo_js_test_0_0 --> tests_test_todo_js_hook_1_0 : beforeAll[0]
+tests_test_todo_js_test_0_0 --> tests_test_todo_js_hook_2_0 : beforeAll[1]
+tests_test_todo_js_test_0_0 --> tests_test_todo_js_hook_3_0 : afterAll[0]
+tests_test_todo_js_test_0_0 --> tests_test_todo_js_hook_4_0 : afterAll[1]
 
 @enduml
 "

--- a/packages/library/src/metadata/__tests__/__snapshots__/run-traversal.test.ts.snap
+++ b/packages/library/src/metadata/__tests__/__snapshots__/run-traversal.test.ts.snap
@@ -1,0 +1,193 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`run metadata traversal: fixtures/29.x.x/env-worker-N/duplicate-cases: allDescribeBlocks 1`] = `"describe_0 → describe_1 → describe_2"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/env-worker-N/duplicate-cases: allInvocations 1`] = `"hook_0.0 → test_0.0.fn → hook_0.1 → test_1.0.fn → hook_0.2 → test_2.0.fn → hook_0.3 → test_3.0.fn"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/env-worker-N/duplicate-cases: allTestEntries 1`] = `"test_0 → test_1 → test_2 → test_3"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/env-worker-N/duplicate-cases: allTestInvocations 1`] = `"test_0.0 → test_1.0 → test_2.0 → test_3.0"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/env-worker-N/duplicate-generation: allDescribeBlocks 1`] = `"describe_0"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/env-worker-N/duplicate-generation: allInvocations 1`] = `"hook_0.0 → test_0.0.fn → hook_0.1 → test_1.0.fn → hook_0.2 → test_0.1.fn"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/env-worker-N/duplicate-generation: allTestEntries 1`] = `"test_0 → test_1"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/env-worker-N/duplicate-generation: allTestInvocations 1`] = `"test_0.0 → test_1.0 → test_0.1"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/env-worker-N/duplicate-name: allDescribeBlocks 1`] = `"describe_0 → describe_1 → describe_2 → describe_3"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/env-worker-N/duplicate-name: allInvocations 1`] = `"hook_1.0 → hook_2.0 → hook_0.0 → test_0.0.fn → hook_0.1 → test_1.0.fn → hook_0.2 → test_1.1.fn → hook_3.0 → hook_4.0 → hook_0.3 → test_4.0.fn → hook_0.4 → test_5.0.fn → hook_0.5 → test_4.1.fn → hook_5.0"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/env-worker-N/duplicate-name: allTestEntries 1`] = `"test_0 → test_1 → test_2 → test_3 → test_4 → test_5"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/env-worker-N/duplicate-name: allTestInvocations 1`] = `"test_0.0 → test_1.0 → test_1.1 → test_2.0 → test_3.0 → test_4.0 → test_5.0 → test_4.1"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/env-worker-N/hook-afterAll-fail: allDescribeBlocks 1`] = `"describe_0 → describe_1"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/env-worker-N/hook-afterAll-fail: allInvocations 1`] = `"hook_0.0 → test_0.0.fn → hook_2.0 → hook_1.0"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/env-worker-N/hook-afterAll-fail: allTestEntries 1`] = `"test_0"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/env-worker-N/hook-afterAll-fail: allTestInvocations 1`] = `"test_0.0"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/env-worker-N/hook-beforeAll-fail: allDescribeBlocks 1`] = `"describe_0 → describe_1"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/env-worker-N/hook-beforeAll-fail: allInvocations 1`] = `"hook_1.0 → test_1.0.fn"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/env-worker-N/hook-beforeAll-fail: allTestEntries 1`] = `"test_0 → test_1"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/env-worker-N/hook-beforeAll-fail: allTestInvocations 1`] = `"test_0.0 → test_1.0"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/env-worker-N/hook-nesting: allDescribeBlocks 1`] = `"describe_0 → describe_1"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/env-worker-N/hook-nesting: allInvocations 1`] = `"hook_1.0 → hook_0.0 → hook_2.0 → test_0.0.fn → hook_3.0 → hook_0.1 → hook_2.1 → test_1.0.fn → hook_3.1 → hook_4.0"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/env-worker-N/hook-nesting: allTestEntries 1`] = `"test_0 → test_1"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/env-worker-N/hook-nesting: allTestInvocations 1`] = `"test_0.0 → test_1.0"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/env-worker-N/test-concurrent: allDescribeBlocks 1`] = `"describe_0"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/env-worker-N/test-concurrent: allInvocations 1`] = `"test_0.0.fn → test_1.0.fn → test_2.0.fn → test_3.0.fn → test_4.0.fn"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/env-worker-N/test-concurrent: allTestEntries 1`] = `"test_0 → test_1 → test_2 → test_3 → test_4"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/env-worker-N/test-concurrent: allTestInvocations 1`] = `"test_0.0 → test_1.0 → test_2.0 → test_3.0 → test_4.0"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/env-worker-N/test-fail: allDescribeBlocks 1`] = `"describe_0"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/env-worker-N/test-fail: allInvocations 1`] = `"hook_0.0 → test_0.0.fn"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/env-worker-N/test-fail: allTestEntries 1`] = `"test_0"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/env-worker-N/test-fail: allTestInvocations 1`] = `"test_0.0"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/env-worker-N/test-pass: allDescribeBlocks 1`] = `"describe_0"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/env-worker-N/test-pass: allInvocations 1`] = `"hook_0.0 → test_0.0.fn"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/env-worker-N/test-pass: allTestEntries 1`] = `"test_0"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/env-worker-N/test-pass: allTestInvocations 1`] = `"test_0.0"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/env-worker-N/test-retry: allDescribeBlocks 1`] = `"describe_0"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/env-worker-N/test-retry: allInvocations 1`] = `"hook_1.0 → hook_0.0 → test_0.0.fn → hook_0.1 → test_0.1.fn → hook_2.0"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/env-worker-N/test-retry: allTestEntries 1`] = `"test_0"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/env-worker-N/test-retry: allTestInvocations 1`] = `"test_0.0 → test_0.1"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/env-worker-N/test-skip: allDescribeBlocks 1`] = `"describe_0 → describe_1 → describe_2"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/env-worker-N/test-skip: allInvocations 1`] = `""`;
+
+exports[`run metadata traversal: fixtures/29.x.x/env-worker-N/test-skip: allTestEntries 1`] = `"test_0"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/env-worker-N/test-skip: allTestInvocations 1`] = `"test_0.0"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/env-worker-N/test-todo: allDescribeBlocks 1`] = `"describe_0 → describe_1 → describe_2"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/env-worker-N/test-todo: allInvocations 1`] = `"hook_1.0 → hook_2.0 → hook_3.0 → hook_4.0"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/env-worker-N/test-todo: allTestEntries 1`] = `"test_0"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/env-worker-N/test-todo: allTestInvocations 1`] = `"test_0.0"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/no-env-worker-N/duplicate-cases: allDescribeBlocks 1`] = `"describe_0"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/no-env-worker-N/duplicate-cases: allInvocations 1`] = `""`;
+
+exports[`run metadata traversal: fixtures/29.x.x/no-env-worker-N/duplicate-cases: allTestEntries 1`] = `"test_0 → test_1 → test_2 → test_3"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/no-env-worker-N/duplicate-cases: allTestInvocations 1`] = `"test_0.0 → test_1.0 → test_2.0 → test_3.0"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/no-env-worker-N/duplicate-generation: allDescribeBlocks 1`] = `"describe_0"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/no-env-worker-N/duplicate-generation: allInvocations 1`] = `""`;
+
+exports[`run metadata traversal: fixtures/29.x.x/no-env-worker-N/duplicate-generation: allTestEntries 1`] = `"test_0 → test_1"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/no-env-worker-N/duplicate-generation: allTestInvocations 1`] = `"test_0.0 → test_1.0"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/no-env-worker-N/duplicate-name: allDescribeBlocks 1`] = `"describe_0"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/no-env-worker-N/duplicate-name: allInvocations 1`] = `""`;
+
+exports[`run metadata traversal: fixtures/29.x.x/no-env-worker-N/duplicate-name: allTestEntries 1`] = `"test_0 → test_1 → test_2 → test_3 → test_4 → test_5"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/no-env-worker-N/duplicate-name: allTestInvocations 1`] = `"test_0.0 → test_1.0 → test_2.0 → test_3.0 → test_4.0 → test_5.0"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/no-env-worker-N/hook-afterAll-fail: allDescribeBlocks 1`] = `"describe_0"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/no-env-worker-N/hook-afterAll-fail: allInvocations 1`] = `""`;
+
+exports[`run metadata traversal: fixtures/29.x.x/no-env-worker-N/hook-afterAll-fail: allTestEntries 1`] = `"test_0"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/no-env-worker-N/hook-afterAll-fail: allTestInvocations 1`] = `"test_0.0"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/no-env-worker-N/hook-beforeAll-fail: allDescribeBlocks 1`] = `"describe_0"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/no-env-worker-N/hook-beforeAll-fail: allInvocations 1`] = `""`;
+
+exports[`run metadata traversal: fixtures/29.x.x/no-env-worker-N/hook-beforeAll-fail: allTestEntries 1`] = `"test_0 → test_1"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/no-env-worker-N/hook-beforeAll-fail: allTestInvocations 1`] = `"test_0.0 → test_1.0"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/no-env-worker-N/hook-nesting: allDescribeBlocks 1`] = `"describe_0"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/no-env-worker-N/hook-nesting: allInvocations 1`] = `""`;
+
+exports[`run metadata traversal: fixtures/29.x.x/no-env-worker-N/hook-nesting: allTestEntries 1`] = `"test_0 → test_1"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/no-env-worker-N/hook-nesting: allTestInvocations 1`] = `"test_0.0 → test_1.0"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/no-env-worker-N/test-concurrent: allDescribeBlocks 1`] = `"describe_0"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/no-env-worker-N/test-concurrent: allInvocations 1`] = `""`;
+
+exports[`run metadata traversal: fixtures/29.x.x/no-env-worker-N/test-concurrent: allTestEntries 1`] = `"test_0 → test_1 → test_2 → test_3 → test_4"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/no-env-worker-N/test-concurrent: allTestInvocations 1`] = `"test_0.0 → test_1.0 → test_2.0 → test_3.0 → test_4.0"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/no-env-worker-N/test-fail: allDescribeBlocks 1`] = `"describe_0"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/no-env-worker-N/test-fail: allInvocations 1`] = `""`;
+
+exports[`run metadata traversal: fixtures/29.x.x/no-env-worker-N/test-fail: allTestEntries 1`] = `"test_0"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/no-env-worker-N/test-fail: allTestInvocations 1`] = `"test_0.0"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/no-env-worker-N/test-pass: allDescribeBlocks 1`] = `"describe_0"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/no-env-worker-N/test-pass: allInvocations 1`] = `""`;
+
+exports[`run metadata traversal: fixtures/29.x.x/no-env-worker-N/test-pass: allTestEntries 1`] = `"test_0"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/no-env-worker-N/test-pass: allTestInvocations 1`] = `"test_0.0"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/no-env-worker-N/test-retry: allDescribeBlocks 1`] = `"describe_0"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/no-env-worker-N/test-retry: allInvocations 1`] = `""`;
+
+exports[`run metadata traversal: fixtures/29.x.x/no-env-worker-N/test-retry: allTestEntries 1`] = `"test_0"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/no-env-worker-N/test-retry: allTestInvocations 1`] = `"test_0.0"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/no-env-worker-N/test-skip: allDescribeBlocks 1`] = `""`;
+
+exports[`run metadata traversal: fixtures/29.x.x/no-env-worker-N/test-skip: allInvocations 1`] = `""`;
+
+exports[`run metadata traversal: fixtures/29.x.x/no-env-worker-N/test-skip: allTestEntries 1`] = `""`;
+
+exports[`run metadata traversal: fixtures/29.x.x/no-env-worker-N/test-skip: allTestInvocations 1`] = `""`;
+
+exports[`run metadata traversal: fixtures/29.x.x/no-env-worker-N/test-todo: allDescribeBlocks 1`] = `"describe_0"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/no-env-worker-N/test-todo: allInvocations 1`] = `""`;
+
+exports[`run metadata traversal: fixtures/29.x.x/no-env-worker-N/test-todo: allTestEntries 1`] = `"test_0"`;
+
+exports[`run metadata traversal: fixtures/29.x.x/no-env-worker-N/test-todo: allTestInvocations 1`] = `"test_0.0"`;

--- a/packages/library/src/metadata/__tests__/run-traversal.test.ts
+++ b/packages/library/src/metadata/__tests__/run-traversal.test.ts
@@ -1,0 +1,49 @@
+import fixtures from '@jest-metadata/fixtures';
+
+import {
+  AggregatedMetadataRegistry,
+  Metadata,
+  MetadataEventHandler,
+  MetadataFactoryImpl,
+  SetMetadataEventEmitter,
+} from '..';
+
+import { SerialSyncEmitter } from '../../utils';
+
+describe('run metadata traversal:', () => {
+  const lastFixtures = Object.values(fixtures).filter(([name]) => {
+    return name.startsWith('29.x.x') && name.includes('-worker-N');
+  });
+
+  test.each(lastFixtures)(`fixtures/%s`, (_name: string, fixture: any[]) => {
+    const emitter: SetMetadataEventEmitter = new SerialSyncEmitter('set');
+    const metadataRegistry = new AggregatedMetadataRegistry();
+    const metadataFactory = new MetadataFactoryImpl(metadataRegistry, emitter);
+    const aggregatedResultMetadata = metadataFactory.createAggregatedResultMetadata();
+    const eventHandler = new MetadataEventHandler({
+      aggregatedResultMetadata,
+      metadataRegistry,
+    });
+
+    for (const event of fixture) {
+      eventHandler.handle(event);
+    }
+
+    const lastRun = aggregatedResultMetadata.lastTestResult!;
+    if (!lastRun) {
+      return;
+    }
+
+    const toId = (x: Metadata) => {
+      const [a, b] = x.id.split(':');
+      return b || a;
+    };
+
+    const toChain = (x: Metadata[]) => x.map(toId).join(' → ');
+
+    expect(toChain([...lastRun.allDescribeBlocks()])).toMatchSnapshot('allDescribeBlocks');
+    expect(toChain([...lastRun.allTestEntries()])).toMatchSnapshot('allTestEntries');
+    expect(toChain([...lastRun.allTestInvocations()])).toMatchSnapshot('allTestInvocations');
+    expect(toChain([...lastRun.allInvocations()])).toMatchSnapshot('allInvocations');
+  });
+});

--- a/packages/library/src/metadata/containers/HookDefinitionMetadata.ts
+++ b/packages/library/src/metadata/containers/HookDefinitionMetadata.ts
@@ -60,7 +60,7 @@ export class HookDefinitionMetadata extends BaseMetadata {
       case 'afterAll': {
         checker
           .asDescribeBlockMetadata(parent)!
-          .invocations.push(invocation as HookInvocationMetadata<DescribeBlockMetadata>);
+          [symbols.pushExecution](invocation as HookInvocationMetadata<DescribeBlockMetadata>);
         break;
       }
     }

--- a/packages/library/src/metadata/containers/RunMetadata.ts
+++ b/packages/library/src/metadata/containers/RunMetadata.ts
@@ -3,7 +3,10 @@ import * as symbols from '../symbols';
 
 import { BaseMetadata } from './BaseMetadata';
 import type { DescribeBlockMetadata } from './DescribeBlockMetadata';
+import type { HookInvocationMetadata } from './HookInvocationMetadata';
 import type { TestEntryMetadata } from './TestEntryMetadata';
+import type { TestFnInvocationMetadata } from './TestFnInvocationMetadata';
+import type { TestInvocationMetadata } from './TestInvocationMetadata';
 
 export class RunMetadata extends BaseMetadata {
   [symbols.rootDescribeBlock]: DescribeBlockMetadata | undefined;
@@ -55,9 +58,15 @@ export class RunMetadata extends BaseMetadata {
     }
   }
 
-  *allInvocations() {
+  *allInvocations(): IterableIterator<HookInvocationMetadata | TestFnInvocationMetadata> {
     if (this[symbols.rootDescribeBlock]) {
       yield* this[symbols.rootDescribeBlock].allInvocations();
+    }
+  }
+
+  *allTestInvocations(): IterableIterator<TestInvocationMetadata> {
+    if (this[symbols.rootDescribeBlock]) {
+      yield* this[symbols.rootDescribeBlock].allTestInvocations();
     }
   }
 }

--- a/packages/library/src/metadata/containers/TestEntryMetadata.ts
+++ b/packages/library/src/metadata/containers/TestEntryMetadata.ts
@@ -34,7 +34,7 @@ export class TestEntryMetadata extends BaseMetadata {
     const invocation = this[symbols.context].factory.createTestInvocationMetadata(this, id);
 
     this.invocations.push(invocation);
-    this.describeBlock.invocations.push(invocation);
+    this.describeBlock[symbols.pushExecution](invocation);
 
     const run = this.describeBlock.run;
     run[symbols.currentMetadata] = invocation;

--- a/packages/library/src/metadata/containers/TestInvocationMetadata.ts
+++ b/packages/library/src/metadata/containers/TestInvocationMetadata.ts
@@ -2,15 +2,18 @@ import type { AggregatedIdentifier } from '../ids';
 import * as symbols from '../symbols';
 
 import { BaseMetadata } from './BaseMetadata';
+import type { DescribeBlockMetadata } from './DescribeBlockMetadata';
 import type { HookInvocationMetadata } from './HookInvocationMetadata';
 import type { MetadataContext } from './MetadataContext';
 import type { TestEntryMetadata } from './TestEntryMetadata';
 import type { TestFnInvocationMetadata } from './TestFnInvocationMetadata';
 
 export class TestInvocationMetadata extends BaseMetadata {
+  readonly beforeAll: HookInvocationMetadata<DescribeBlockMetadata>[] = [];
   readonly before: HookInvocationMetadata<TestInvocationMetadata>[] = [];
   fn?: TestFnInvocationMetadata;
   readonly after: HookInvocationMetadata<TestInvocationMetadata>[] = [];
+  readonly afterAll: HookInvocationMetadata<DescribeBlockMetadata>[] = [];
 
   constructor(
     context: MetadataContext,
@@ -25,10 +28,35 @@ export class TestInvocationMetadata extends BaseMetadata {
     const fn = this[symbols.context].factory.createTestFnInvocationMetadata(this, id);
     const run = this.entry.describeBlock.run;
     run[symbols.currentMetadata] = this.fn = fn;
+    this.entry.describeBlock[symbols.pushBeforeAll](this);
+  }
+
+  [symbols.pushBeforeAll](metadatas: HookInvocationMetadata<DescribeBlockMetadata>[]): void {
+    this.beforeAll.push(...metadatas);
+  }
+
+  [symbols.pushAfterAll](metadatas: HookInvocationMetadata<DescribeBlockMetadata>[]): void {
+    this.afterAll.push(...metadatas);
   }
 
   [symbols.finish](): void {
     const run = this.entry.describeBlock.run;
     run[symbols.currentMetadata] = this;
+  }
+
+  *invocations(): IterableIterator<
+    HookInvocationMetadata<TestInvocationMetadata> | TestFnInvocationMetadata
+  > {
+    yield* this.before;
+    if (this.fn) {
+      yield this.fn;
+    }
+    yield* this.after;
+  }
+
+  *allInvocations(): IterableIterator<HookInvocationMetadata | TestFnInvocationMetadata> {
+    yield* this.beforeAll;
+    yield* this.invocations();
+    yield* this.afterAll;
   }
 }

--- a/packages/library/src/metadata/symbols.ts
+++ b/packages/library/src/metadata/symbols.ts
@@ -9,3 +9,6 @@ export const finish = Symbol('FINISH');
 export const id = Symbol('ID');
 export const rootDescribeBlock = Symbol('ROOT_DESCRIBE_BLOCK');
 export const start = Symbol('START');
+export const pushExecution = Symbol('PUSH_EXECUTION');
+export const pushBeforeAll = Symbol('PUSH_BEFORE_ALL');
+export const pushAfterAll = Symbol('PUSH_AFTER_ALL');


### PR DESCRIPTION
In `jest-circus`, `beforeAll` and `afterAll` hooks are generally tied to the "describe block" and not to individual tests. However, for `jest-metadata` users, associating these hooks with specific tests can be vital.

For example, in Allure reports, where the test case is the central entity and there is no concept of an independent test suite, we can logically assign the beforeAll and afterAll hooks to the closest matching test. This allows the reporter to display them as inner steps of a test.

Despite some complexities mentioned below, this PR provides a valuable virtual mapping of `beforeAll` and `afterAll` hooks to individual test invocations, enhancing the reporting capabilities for certain use cases.