### PR TITLE
build: add benchmark project

### DIFF
--- a/packages/benchmark/.gitignore
+++ b/packages/benchmark/.gitignore
@@ -1,0 +1,1 @@
+/results.json

--- a/packages/benchmark/__tests__/suite1.js
+++ b/packages/benchmark/__tests__/suite1.js
@@ -1,0 +1,7 @@
+const { generateTests } = require('../utils');
+
+describe('Passing suite', () => {
+  test.each(generateTests())('%i + %i should be %i', (a, b, c) => {
+    expect(a + b).toBe(c);
+  });
+});

--- a/packages/benchmark/__tests__/suite2.js
+++ b/packages/benchmark/__tests__/suite2.js
@@ -1,0 +1,7 @@
+const { generateTests } = require('../utils');
+
+describe('Failing suite', () => {
+  test.each(generateTests())('%i + %i should be %i', (a, b, c) => {
+    expect(a + b).not.toBe(c);
+  });
+});

--- a/packages/benchmark/__tests__/suite3.js
+++ b/packages/benchmark/__tests__/suite3.js
@@ -1,0 +1,7 @@
+const { generateTests } = require('../utils');
+
+describe('Skipped suite', () => {
+  test.skip.each(generateTests())('%i + %i should be %i', (a, b, c) => {
+    expect(a + b).toBe(c);
+  });
+});

--- a/packages/benchmark/benchmarkReporter.js
+++ b/packages/benchmark/benchmarkReporter.js
@@ -1,0 +1,28 @@
+const fs = require('fs');
+
+/**
+ * @implements {import('@jest/reporters').Reporter}
+ */
+class BenchmarkReporter {
+  onRunComplete(testContexts, results) {
+    const duration = Date.now() - results.startTime;
+    const preset = process.env.PRESET;
+    const numTests = results.numTotalTests;
+
+    if (preset) {
+      let results;
+      try {
+        results = JSON.parse(fs.readFileSync('results.json', 'utf8'));
+      } catch {
+        results = {};
+      }
+
+      results[numTests] = results[numTests] || {};
+      results[numTests][preset] = duration;
+
+      fs.writeFileSync('results.json', JSON.stringify(results, null, 2));
+    }
+  }
+}
+
+module.exports = BenchmarkReporter;

--- a/packages/benchmark/jest.config.js
+++ b/packages/benchmark/jest.config.js
@@ -1,0 +1,49 @@
+const PRESET = process.env.PRESET || 'metadata-N';
+
+const mixins = {
+  env: () => ({
+    testEnvironment: 'jest-metadata/environment-node',
+  }),
+  reporter: (enable) => ({
+    reporters: [
+      ...(enable ? ['jest-metadata/reporter'] : []),
+      './benchmarkReporter',
+    ],
+  }),
+  workers: (n) => ({
+    maxWorkers: n,
+  }),
+};
+
+const presets = {
+  'metadata-1': {
+    ...mixins.env(),
+    ...mixins.reporter(true),
+    ...mixins.workers(3),
+  },
+  'metadata-N': {
+    ...mixins.env(),
+    ...mixins.reporter(true),
+    ...mixins.workers(3),
+  },
+  'fallback-1': {
+    ...mixins.reporter(true),
+    ...mixins.workers(1),
+  },
+  'fallback-N': {
+    ...mixins.reporter(true),
+    ...mixins.workers(3),
+  },
+  'baseline-1': {
+    ...mixins.reporter(false),
+    ...mixins.workers(1),
+  },
+  'baseline-N': {
+    ...mixins.reporter(false),
+    ...mixins.workers(3),
+  },
+};
+
+module.exports = {
+  ...presets[PRESET],
+};

--- a/packages/benchmark/package.json
+++ b/packages/benchmark/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@jest-metadata/benchmark",
+  "description": "Benchmarks to avoid performance regressions in jest-metadata",
+  "private": true,
+  "version": "1.0.0-beta.13",
+  "devDependencies": {
+    "cross-env": "^7.0.3",
+    "jest": "latest",
+    "jest-metadata": "^1.0.0-beta.13"
+  },
+  "scripts": {
+    "bench:dev": "npm run build --workspace=jest-metadata && npm run bench",
+    "bench": "npm run bench:1 && npm run bench:10 && npm run bench:100 && npm run bench:1000 && npm run bench:10000",
+    "bench:1": "cross-env NUM_TESTS=1 npm run bench:all",
+    "bench:10": "cross-env NUM_TESTS=10 npm run bench:all",
+    "bench:100": "cross-env NUM_TESTS=100 npm run bench:all",
+    "bench:1000": "cross-env NUM_TESTS=1000 npm run bench:all",
+    "bench:10000": "cross-env NUM_TESTS=10000 npm run bench:all",
+    "bench:all": "npm run bench:baseline-1 ; npm run bench:baseline-N ; npm run bench:fallback-1 ; npm run bench:fallback-N ; npm run bench:metadata-1 ; npm run bench:metadata-N ; true",
+    "bench:metadata-1": "cross-env PRESET=metadata-1 jest",
+    "bench:metadata-N": "cross-env PRESET=metadata-N jest",
+    "bench:fallback-1": "cross-env PRESET=fallback-1 jest",
+    "bench:fallback-N": "cross-env PRESET=fallback-N jest",
+    "bench:baseline-1": "cross-env PRESET=baseline-1 jest",
+    "bench:baseline-N": "cross-env PRESET=baseline-N jest"
+  }
+}

--- a/packages/benchmark/utils.js
+++ b/packages/benchmark/utils.js
@@ -1,0 +1,16 @@
+function generateTests() {
+  const num = process.env.NUM_TESTS || '1';
+  return Array.from({length: +num}, () => {
+    const a = randomInt(1, 100);
+    const b = randomInt(1, 100);
+    return [a, b, a + b];
+  });
+}
+
+function randomInt(min, max) {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+module.exports = {
+  generateTests,
+};

--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -47,11 +47,6 @@
       "require": "./dist/reporter.js",
       "types": "./dist/reporter.d.ts"
     },
-    "./server": {
-      "import": "./dist/server.js",
-      "require": "./dist/server.js",
-      "types": "./dist/server.d.ts"
-    },
     "./package.json": "./package.json"
   },
   "engines": {

--- a/packages/recorder/package.json
+++ b/packages/recorder/package.json
@@ -11,7 +11,7 @@
     "semver": "^7.5.4"
   },
   "scripts": {
-    "build:dev": "cd ../library && npm run build && npm run instrument && cd - && npm run build",
+    "build:dev": "npm run build --workspace=jest-metadata && npm run instrument --workspace=jest-metadata && npm run build",
     "build": "npm run build:env-1 ; npm run build:env-N ; npm run build:no-env-1 ; npm run build:no-env-N ; true",
     "build:env-1": "cross-env PRESET=env-1 jest",
     "build:env-N": "cross-env PRESET=env-N jest",


### PR DESCRIPTION
So, overall, we can see that `jest-metadata` currently adds about 0.5ms per test.

For E2E projects, this difference should be barely noticeable.
For large unit test projects (e.g. about 60,000 tests), this difference can add about 20s extra.

![X-Y plot](https://github.com/wix-incubator/jest-metadata/assets/1962469/5b776ccc-27de-4bad-bef4-edadbe2d9e68)

