### PR TITLE
fix: confusing error when no reporter

### DIFF
--- a/e2e/jest-recorder.config.js
+++ b/e2e/jest-recorder.config.js
@@ -37,6 +37,16 @@ const presets = {
     ...mixins.env(true),
     ...mixins.workers(2),
   },
+  'no-reporter-1': {
+    ...mixins.env(true),
+    ...mixins.workers(2),
+    reporters: ['default'],
+  },
+  'no-reporter-N': {
+    ...mixins.env(true),
+    ...mixins.workers(2),
+    reporters: ['default'],
+  },
   'no-env-1': {
     ...mixins.env(false),
     ...mixins.workers(1),

--- a/src/metadata/containers/GlobalMetadata.ts
+++ b/src/metadata/containers/GlobalMetadata.ts
@@ -31,12 +31,15 @@ export class GlobalMetadata extends BaseMetadata {
   }
 
   public getTestFileMetadata(testFilePath: string): TestFileMetadata {
-    const testFileMetadata = this[$byTestFilePath].get(testFilePath);
-    if (!testFileMetadata) {
+    if (!this.hasTestFileMetadata(testFilePath)) {
       throw new JestMetadataError(`No file metadata found for: ${testFilePath}`);
     }
 
-    return testFileMetadata;
+    return this[$byTestFilePath].get(testFilePath)!;
+  }
+
+  public hasTestFileMetadata(testFilePath: string): boolean {
+    return this[$byTestFilePath].has(testFilePath);
   }
 
   public registerTestFile(testFilePath: string): TestFileMetadata {


### PR DESCRIPTION
Resolves #45.

If a user forgets to add a jest-metadata compatible reporter to their Jest configuration, they will see errors like this:

```
JestMetadataError: No file metadata found for: ...
```

That is a confusing error, so this pull request improves it:

```
JestMetadataError: Cannot use a metadata test environment without a metadata server.
Please check that at least one of the reporters in your Jest config inherits from "jest-metadata/reporter".
  "reporters": ["default"]
```
