### PR TITLE
fix: support duplicate installations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-metadata",
-  "version": "1.0.0-beta.23",
+  "version": "1.0.0",
   "description": "Extend Jest with custom metadata",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/realms/detect.ts
+++ b/src/realms/detect.ts
@@ -19,12 +19,25 @@ export function isJestWorker(): boolean {
   return 'JEST_WORKER_ID' in process.env;
 }
 
-export function injectRealmIntoSandbox(sandbox: any, realm: ProcessRealm): void {
+export function injectRealmIntoSandbox(sandbox: any, realm: ProcessRealm): ProcessRealm {
   sandbox.__JEST_METADATA__ = realm;
+  if (sandbox !== globalThis) {
+    sandbox.__JEST_METADATA_SANDBOX__ = true;
+  }
+
+  return realm;
 }
 
 export function getSandboxedRealm(): ProcessRealm | undefined {
-  return (global as any).__JEST_METADATA__;
+  const globalAny = globalThis as any;
+  const realm = globalAny.__JEST_METADATA__;
+  if (realm && !globalAny.__JEST_METADATA_SANDBOX__) {
+    console.warn(
+      '[jest-metadata] Detected duplicate jest-metadata package in the same process. This may lead to unexpected behavior.',
+    );
+  }
+
+  return realm;
 }
 
 export function getServerId(): string | undefined {

--- a/src/realms/realm.ts
+++ b/src/realms/realm.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-var-requires,node/no-missing-require */
 // TODO: think about ESM support via dynamic import
-import { getSandboxedRealm, isClient } from './detect';
+import { getSandboxedRealm, injectRealmIntoSandbox, isClient } from './detect';
 import type { ProcessRealm } from './ProcessRealm';
 
 function createRealm(): ProcessRealm {
@@ -13,4 +13,4 @@ function createRealm(): ProcessRealm {
   }
 }
 
-export default getSandboxedRealm() ?? createRealm();
+export default getSandboxedRealm() ?? injectRealmIntoSandbox(globalThis, createRealm());


### PR DESCRIPTION
Fixes a rare issue discovered while testing [#4212](https://github.com/wix/Detox/pull/4212).

```
outer_project
├── node_modules
│   ├── jest-metadata (1)
├── inner_project
│   ├── node_modules
│   │   ├── jest-metadata (2)
```

Sometimes, there might be duplicate `jest-metadata` installations, even if the version is the same.

This **already** creates a weird indeterministic behaviour, so this pull request improves the situation:

1) it injects into _non-sandboxed_ `globalThis` the entire jest-metadata's realm object
2) it prefers that injected object anytime it can
3) it issues a warning if the realm object has already been injected into _non-sandboxed_ `globalThis`.

This doesn't guarantee deterministic behaviour, but at least users will see the warning in the logs, so this type of misconfiguration can be spotted without deep debugging.