### PR TITLE
feat: sync global metadata

### DIFF
--- a/src/ipc/BatchMessage.ts
+++ b/src/ipc/BatchMessage.ts
@@ -1,0 +1,10 @@
+import type { MetadataEvent } from '../metadata';
+
+export type BatchMessage = {
+  /** The batch of messages. */
+  batch: MetadataEvent[];
+  /** Whether this is the first batch of messages. */
+  first?: boolean;
+  /** Whether this is the last batch of messages. */
+  last?: boolean;
+};

--- a/src/ipc/IPCClient.ts
+++ b/src/ipc/IPCClient.ts
@@ -2,8 +2,10 @@ import node_ipc from 'node-ipc';
 import stripAnsi from 'strip-ansi';
 
 import { JestMetadataError } from '../errors';
-import type { MetadataEvent } from '../metadata';
+import type { GlobalMetadata, MetadataEvent } from '../metadata';
+import { internal } from '../metadata';
 import { logger, optimizeForLogger } from '../utils';
+import type { BatchMessage } from './BatchMessage';
 import { sendAsyncMessage } from './sendAsyncMessage';
 
 const log = logger.child({ cat: 'ipc', tid: 'ipc-client' });
@@ -15,6 +17,7 @@ export type IPCClientConfig = {
   appspace: string;
   clientId: string | undefined;
   serverId: string | undefined;
+  globalMetadata: GlobalMetadata;
 };
 
 const __SEND = optimizeForLogger((msg: unknown) => ({ msg }));
@@ -28,6 +31,7 @@ export class IPCClient {
   private _stopPromise?: Promise<void>;
   private _queue: MetadataEvent[] = [];
   private _connection?: IPCConnection;
+  private _globalMetadata: GlobalMetadata;
 
   constructor(config: IPCClientConfig) {
     if (!config.serverId) {
@@ -38,6 +42,7 @@ export class IPCClient {
       throw new JestMetadataError('IPC client ID is not specified when creating IPC client.');
     }
 
+    this._globalMetadata = config.globalMetadata;
     this._ipc = new node_ipc.IPC();
     this._serverId = config.serverId;
 
@@ -79,7 +84,7 @@ export class IPCClient {
     this._queue.push(event);
   }
 
-  async flush(last: boolean = false): Promise<void> {
+  async flush(modifier?: 'first' | 'last'): Promise<void> {
     if (!this._connection) {
       log.trace(__OMIT(this._queue), 'flush (no connection)');
       return;
@@ -87,11 +92,20 @@ export class IPCClient {
 
     const connection = this._connection;
     const batch = this._queue.splice(0, this._queue.length);
-    if (last || batch.length > 0) {
-      const msg = { last, batch };
-      await log.trace.complete(__SEND(msg), 'send', () =>
-        sendAsyncMessage(connection, 'clientMessageBatch', msg),
-      );
+    if (modifier || batch.length > 0) {
+      const msg: BatchMessage = { batch };
+      if (modifier === 'first') {
+        msg.first = true;
+      }
+      if (modifier === 'last') {
+        msg.last = true;
+      }
+
+      await log.trace.complete(__SEND(msg), 'send', async () => {
+        const data = await sendAsyncMessage(connection, 'clientMessageBatch', msg);
+        // Direct update to avoid emitting events.
+        Object.assign(this._globalMetadata[internal.data], data);
+      });
     } else {
       log.trace('empty-queue');
     }
@@ -125,7 +139,7 @@ export class IPCClient {
     if (connection) {
       this._connection = connection;
       this._connection.on('beforeExit', () => this.stop());
-      await this.flush();
+      await this.flush('first');
     }
   }
 
@@ -134,7 +148,7 @@ export class IPCClient {
     this._startPromise = undefined;
 
     if (this._connection) {
-      await this.flush(true);
+      await this.flush('last');
       await new Promise((resolve, reject) => {
         this._ipc.of[this._serverId]
           // @ts-expect-error TS2339: Property 'once' does not exist on type 'Client'.

--- a/src/ipc/IPCServer.ts
+++ b/src/ipc/IPCServer.ts
@@ -3,22 +3,18 @@ import type { Socket } from 'net';
 import node_ipc from 'node-ipc';
 import stripAnsi from 'strip-ansi';
 
-import type { MetadataEvent, MetadataEventEmitter } from '../metadata';
+import type { Metadata, MetadataEventEmitter } from '../metadata';
 import { Deferred, logger, makeDeferred, optimizeForLogger } from '../utils';
+import type { BatchMessage } from './BatchMessage';
 
 const log = logger.child({ cat: 'ipc', tid: 'ipc-server' });
 
 type IPC = Omit<typeof node_ipc, 'IPC'>;
 
-type BatchMessage = {
-  /** Whether this is the last batch of messages. */
-  last: boolean;
-  batch: MetadataEvent[];
-};
-
 export type IPCServerConfig = {
   appspace: string;
   serverId: string;
+  globalMetadata: Metadata;
   emitter: MetadataEventEmitter;
 };
 
@@ -27,6 +23,7 @@ export class IPCServer {
   private _stopPromise?: Promise<void>;
   private _flushDeferred?: Deferred<void>;
   private readonly _ipc: IPC;
+  private readonly _globalMetadata: Metadata;
   private readonly _emitter: MetadataEventEmitter;
   private readonly _knownSockets = new Set<Socket>();
 
@@ -35,6 +32,7 @@ export class IPCServer {
     this._ipc.config.id = config.serverId;
     this._ipc.config.appspace = config.appspace;
     this._ipc.config.logger = optimizeForLogger((msg) => log.trace(stripAnsi(msg)));
+    this._globalMetadata = config.globalMetadata;
     this._emitter = config.emitter;
   }
 
@@ -93,7 +91,7 @@ export class IPCServer {
     });
   }
 
-  private _onClientMessageBatch({ last, batch }: BatchMessage, socket: Socket) {
+  private _onClientMessageBatch({ batch, first, last }: BatchMessage, socket: Socket) {
     for (const event of batch) {
       if (event.type !== 'add_test_file') {
         // Jest Metadata server adds new test files before we get
@@ -103,7 +101,8 @@ export class IPCServer {
       }
     }
 
-    this._ipc.server.emit(socket, 'clientMessageBatchDone');
+    const payload = first ? this._globalMetadata.get() : void 0;
+    this._ipc.server.emit(socket, 'clientMessageBatchDone', payload);
 
     if (last) {
       this._knownSockets.delete(socket);

--- a/src/realms/ChildProcessRealm.ts
+++ b/src/realms/ChildProcessRealm.ts
@@ -16,6 +16,7 @@ export class ChildProcessRealm extends BaseRealm {
     appspace: `jest-metadata@${getVersion()}-`,
     serverId: getServerId()!,
     clientId: getClientId(),
+    globalMetadata: this.globalMetadata,
   });
 
   constructor() {

--- a/src/realms/ParentProcessRealm.ts
+++ b/src/realms/ParentProcessRealm.ts
@@ -12,6 +12,7 @@ export class ParentProcessRealm extends BaseRealm {
     appspace: `jest-metadata@${getVersion()}-`,
     serverId: `${process.pid}`,
     emitter: this.coreEmitter,
+    globalMetadata: this.globalMetadata,
   });
 
   readonly fallbackAPI = new FallbackAPI(this.globalMetadata, this.coreEmitter);


### PR DESCRIPTION
Resolves #59.

This implementation allows the one-time synchronization of the global metadata when the IPC client connects.

As a user, you don't have a guarantee that you will always have fresh global metadata.

Use it to pass necessary data down to test environments from the reporter.