### PR TITLE
fix: mutations in IPC queue

### DIFF
--- a/e2e/__fixtures__/27.x.x/bail-env-1/globalMetadata.json
+++ b/e2e/__fixtures__/27.x.x/bail-env-1/globalMetadata.json
@@ -1,6 +1,6 @@
 [
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [

--- a/e2e/__fixtures__/27.x.x/bail-env-N/globalMetadata.json
+++ b/e2e/__fixtures__/27.x.x/bail-env-N/globalMetadata.json
@@ -1,6 +1,6 @@
 [
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -9,7 +9,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [

--- a/e2e/__fixtures__/27.x.x/env-1/duplicate-name.json
+++ b/e2e/__fixtures__/27.x.x/env-1/duplicate-name.json
@@ -133,7 +133,7 @@
     "hookId": "hook_1"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "hook_1.0",
     "path": "note",
@@ -156,7 +156,7 @@
     "hookId": "hook_2"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "hook_2.0",
     "path": "note",
@@ -189,7 +189,7 @@
     "testId": "test_0"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "test_0.0.fn",
     "path": "note",
@@ -227,7 +227,7 @@
     "testId": "test_1"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "test_1.0.fn",
     "path": "note",
@@ -270,7 +270,7 @@
     "testId": "test_1"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "test_1.1.fn",
     "path": "note",
@@ -293,7 +293,7 @@
     "hookId": "hook_3"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "hook_3.0",
     "path": "note",
@@ -341,7 +341,7 @@
     "hookId": "hook_4"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "hook_4.0",
     "path": "note",
@@ -374,7 +374,7 @@
     "testId": "test_4"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "test_4.0.fn",
     "path": "note",
@@ -412,7 +412,7 @@
     "testId": "test_5"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "test_5.0.fn",
     "path": "note",
@@ -455,7 +455,7 @@
     "testId": "test_4"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "test_4.1.fn",
     "path": "note",
@@ -478,7 +478,7 @@
     "hookId": "hook_5"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "hook_5.0",
     "path": "note",

--- a/e2e/__fixtures__/27.x.x/env-1/globalMetadata.json
+++ b/e2e/__fixtures__/27.x.x/env-1/globalMetadata.json
@@ -1,6 +1,6 @@
 [
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -9,7 +9,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -18,7 +18,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -27,7 +27,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -36,7 +36,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -45,7 +45,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -54,7 +54,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -63,7 +63,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -72,7 +72,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -81,7 +81,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -90,7 +90,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -99,7 +99,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [

--- a/e2e/__fixtures__/27.x.x/env-1/hook-nesting.json
+++ b/e2e/__fixtures__/27.x.x/env-1/hook-nesting.json
@@ -24,7 +24,7 @@
     "describeId": "describe_1"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "describe_1",
     "path": "vendor.maintainer",
@@ -35,7 +35,7 @@
     "operation": "assign"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "describe_1",
     "path": "vendor.lead",
@@ -46,7 +46,7 @@
     "operation": "merge"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "describe_1",
     "path": "vendor.description",
@@ -60,7 +60,7 @@
     "hookType": "beforeAll"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_1",
     "path": "vendor.description",
@@ -74,7 +74,7 @@
     "hookType": "beforeEach"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_2",
     "path": "vendor.description",
@@ -88,7 +88,7 @@
     "hookType": "afterEach"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_3",
     "path": "vendor.description",
@@ -102,7 +102,7 @@
     "hookType": "afterAll"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_4",
     "path": "vendor.description",
@@ -115,7 +115,7 @@
     "testId": "test_0"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "test_0",
     "path": [
@@ -133,7 +133,7 @@
     "testId": "test_1"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "test_1",
     "path": [
@@ -146,7 +146,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "test_1",
     "path": [
@@ -188,7 +188,7 @@
     "hookId": "hook_1"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_1.0",
     "path": "vendor.steps",
@@ -226,7 +226,7 @@
     "hookId": "hook_2"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_2.0",
     "path": "vendor.steps",
@@ -249,7 +249,7 @@
     "testId": "test_0"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "test_0.0.fn",
     "path": "vendor.steps",
@@ -262,7 +262,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "test_0.0.fn",
     "path": "vendor.steps",
@@ -285,7 +285,7 @@
     "hookId": "hook_3"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_3.0",
     "path": "vendor.steps",
@@ -328,7 +328,7 @@
     "hookId": "hook_2"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_2.1",
     "path": "vendor.steps",
@@ -351,7 +351,7 @@
     "testId": "test_1"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "test_1.0.fn",
     "path": "vendor.steps",
@@ -364,7 +364,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "test_1.0.fn",
     "path": "vendor.steps",
@@ -387,7 +387,7 @@
     "hookId": "hook_3"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_3.1",
     "path": "vendor.steps",
@@ -415,7 +415,7 @@
     "hookId": "hook_4"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_4.0",
     "path": "vendor.steps",

--- a/e2e/__fixtures__/27.x.x/env-1/test-concurrent.json
+++ b/e2e/__fixtures__/27.x.x/env-1/test-concurrent.json
@@ -78,7 +78,7 @@
     "testId": "test_0"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/test-concurrent.js",
     "targetId": "test_0.0.fn",
     "path": "test.slept",
@@ -116,7 +116,7 @@
     "testId": "test_1"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/test-concurrent.js",
     "targetId": "test_1.0.fn",
     "path": "test.slept",
@@ -154,7 +154,7 @@
     "testId": "test_2"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/test-concurrent.js",
     "targetId": "test_2.0.fn",
     "path": "test.slept",
@@ -192,7 +192,7 @@
     "testId": "test_3"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/test-concurrent.js",
     "targetId": "test_3.0.fn",
     "path": "test.slept",
@@ -230,7 +230,7 @@
     "testId": "test_4"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/test-concurrent.js",
     "targetId": "test_4.0.fn",
     "path": "test.slept",

--- a/e2e/__fixtures__/27.x.x/env-1/test-todo.json
+++ b/e2e/__fixtures__/27.x.x/env-1/test-todo.json
@@ -92,7 +92,7 @@
     "hookId": "hook_1"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/test-todo.js",
     "targetId": "hook_1.0",
     "path": "note",
@@ -115,7 +115,7 @@
     "hookId": "hook_2"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/test-todo.js",
     "targetId": "hook_2.0",
     "path": "note",
@@ -143,7 +143,7 @@
     "hookId": "hook_3"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/test-todo.js",
     "targetId": "hook_3.0",
     "path": "note",
@@ -166,7 +166,7 @@
     "hookId": "hook_4"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/test-todo.js",
     "targetId": "hook_4.0",
     "path": "note",

--- a/e2e/__fixtures__/27.x.x/env-N/duplicate-name.json
+++ b/e2e/__fixtures__/27.x.x/env-N/duplicate-name.json
@@ -133,7 +133,7 @@
     "hookId": "hook_1"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "hook_1.0",
     "path": "note",
@@ -156,7 +156,7 @@
     "hookId": "hook_2"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "hook_2.0",
     "path": "note",
@@ -189,7 +189,7 @@
     "testId": "test_0"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "test_0.0.fn",
     "path": "note",
@@ -227,7 +227,7 @@
     "testId": "test_1"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "test_1.0.fn",
     "path": "note",
@@ -270,7 +270,7 @@
     "testId": "test_1"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "test_1.1.fn",
     "path": "note",
@@ -293,7 +293,7 @@
     "hookId": "hook_3"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "hook_3.0",
     "path": "note",
@@ -341,7 +341,7 @@
     "hookId": "hook_4"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "hook_4.0",
     "path": "note",
@@ -374,7 +374,7 @@
     "testId": "test_4"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "test_4.0.fn",
     "path": "note",
@@ -412,7 +412,7 @@
     "testId": "test_5"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "test_5.0.fn",
     "path": "note",
@@ -455,7 +455,7 @@
     "testId": "test_4"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "test_4.1.fn",
     "path": "note",
@@ -478,7 +478,7 @@
     "hookId": "hook_5"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "hook_5.0",
     "path": "note",

--- a/e2e/__fixtures__/27.x.x/env-N/globalMetadata.json
+++ b/e2e/__fixtures__/27.x.x/env-N/globalMetadata.json
@@ -1,6 +1,6 @@
 [
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -9,7 +9,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -18,7 +18,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -27,7 +27,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -36,7 +36,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -45,7 +45,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -54,7 +54,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -63,7 +63,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -72,7 +72,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -81,7 +81,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -90,7 +90,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -99,7 +99,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [

--- a/e2e/__fixtures__/27.x.x/env-N/hook-nesting.json
+++ b/e2e/__fixtures__/27.x.x/env-N/hook-nesting.json
@@ -24,7 +24,7 @@
     "describeId": "describe_1"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "describe_1",
     "path": "vendor.maintainer",
@@ -35,7 +35,7 @@
     "operation": "assign"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "describe_1",
     "path": "vendor.lead",
@@ -46,7 +46,7 @@
     "operation": "merge"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "describe_1",
     "path": "vendor.description",
@@ -60,7 +60,7 @@
     "hookType": "beforeAll"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_1",
     "path": "vendor.description",
@@ -74,7 +74,7 @@
     "hookType": "beforeEach"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_2",
     "path": "vendor.description",
@@ -88,7 +88,7 @@
     "hookType": "afterEach"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_3",
     "path": "vendor.description",
@@ -102,7 +102,7 @@
     "hookType": "afterAll"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_4",
     "path": "vendor.description",
@@ -115,7 +115,7 @@
     "testId": "test_0"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "test_0",
     "path": [
@@ -133,7 +133,7 @@
     "testId": "test_1"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "test_1",
     "path": [
@@ -146,7 +146,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "test_1",
     "path": [
@@ -188,7 +188,7 @@
     "hookId": "hook_1"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_1.0",
     "path": "vendor.steps",
@@ -226,7 +226,7 @@
     "hookId": "hook_2"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_2.0",
     "path": "vendor.steps",
@@ -249,7 +249,7 @@
     "testId": "test_0"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "test_0.0.fn",
     "path": "vendor.steps",
@@ -262,7 +262,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "test_0.0.fn",
     "path": "vendor.steps",
@@ -285,7 +285,7 @@
     "hookId": "hook_3"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_3.0",
     "path": "vendor.steps",
@@ -328,7 +328,7 @@
     "hookId": "hook_2"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_2.1",
     "path": "vendor.steps",
@@ -351,7 +351,7 @@
     "testId": "test_1"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "test_1.0.fn",
     "path": "vendor.steps",
@@ -364,7 +364,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "test_1.0.fn",
     "path": "vendor.steps",
@@ -387,7 +387,7 @@
     "hookId": "hook_3"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_3.1",
     "path": "vendor.steps",
@@ -415,7 +415,7 @@
     "hookId": "hook_4"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_4.0",
     "path": "vendor.steps",

--- a/e2e/__fixtures__/27.x.x/env-N/test-concurrent.json
+++ b/e2e/__fixtures__/27.x.x/env-N/test-concurrent.json
@@ -78,7 +78,7 @@
     "testId": "test_0"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/test-concurrent.js",
     "targetId": "test_0.0.fn",
     "path": "test.slept",
@@ -116,7 +116,7 @@
     "testId": "test_1"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/test-concurrent.js",
     "targetId": "test_1.0.fn",
     "path": "test.slept",
@@ -154,7 +154,7 @@
     "testId": "test_2"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/test-concurrent.js",
     "targetId": "test_2.0.fn",
     "path": "test.slept",
@@ -192,7 +192,7 @@
     "testId": "test_3"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/test-concurrent.js",
     "targetId": "test_3.0.fn",
     "path": "test.slept",
@@ -230,7 +230,7 @@
     "testId": "test_4"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/test-concurrent.js",
     "targetId": "test_4.0.fn",
     "path": "test.slept",

--- a/e2e/__fixtures__/27.x.x/env-N/test-todo.json
+++ b/e2e/__fixtures__/27.x.x/env-N/test-todo.json
@@ -92,7 +92,7 @@
     "hookId": "hook_1"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/test-todo.js",
     "targetId": "hook_1.0",
     "path": "note",
@@ -115,7 +115,7 @@
     "hookId": "hook_2"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/test-todo.js",
     "targetId": "hook_2.0",
     "path": "note",
@@ -143,7 +143,7 @@
     "hookId": "hook_3"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/test-todo.js",
     "targetId": "hook_3.0",
     "path": "note",
@@ -166,7 +166,7 @@
     "hookId": "hook_4"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/test-todo.js",
     "targetId": "hook_4.0",
     "path": "note",

--- a/e2e/__fixtures__/28.x.x/bail-env-1/globalMetadata.json
+++ b/e2e/__fixtures__/28.x.x/bail-env-1/globalMetadata.json
@@ -1,6 +1,6 @@
 [
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [

--- a/e2e/__fixtures__/28.x.x/bail-env-N/globalMetadata.json
+++ b/e2e/__fixtures__/28.x.x/bail-env-N/globalMetadata.json
@@ -1,6 +1,6 @@
 [
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -9,7 +9,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [

--- a/e2e/__fixtures__/28.x.x/env-1/duplicate-name.json
+++ b/e2e/__fixtures__/28.x.x/env-1/duplicate-name.json
@@ -133,7 +133,7 @@
     "hookId": "hook_1"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "hook_1.0",
     "path": "note",
@@ -156,7 +156,7 @@
     "hookId": "hook_2"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "hook_2.0",
     "path": "note",
@@ -189,7 +189,7 @@
     "testId": "test_0"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "test_0.0.fn",
     "path": "note",
@@ -227,7 +227,7 @@
     "testId": "test_1"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "test_1.0.fn",
     "path": "note",
@@ -270,7 +270,7 @@
     "testId": "test_1"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "test_1.1.fn",
     "path": "note",
@@ -293,7 +293,7 @@
     "hookId": "hook_3"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "hook_3.0",
     "path": "note",
@@ -341,7 +341,7 @@
     "hookId": "hook_4"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "hook_4.0",
     "path": "note",
@@ -374,7 +374,7 @@
     "testId": "test_4"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "test_4.0.fn",
     "path": "note",
@@ -412,7 +412,7 @@
     "testId": "test_5"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "test_5.0.fn",
     "path": "note",
@@ -455,7 +455,7 @@
     "testId": "test_4"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "test_4.1.fn",
     "path": "note",
@@ -478,7 +478,7 @@
     "hookId": "hook_5"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "hook_5.0",
     "path": "note",

--- a/e2e/__fixtures__/28.x.x/env-1/globalMetadata.json
+++ b/e2e/__fixtures__/28.x.x/env-1/globalMetadata.json
@@ -1,6 +1,6 @@
 [
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -9,7 +9,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -18,7 +18,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -27,7 +27,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -36,7 +36,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -45,7 +45,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -54,7 +54,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -63,7 +63,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -72,7 +72,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -81,7 +81,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -90,7 +90,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -99,7 +99,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [

--- a/e2e/__fixtures__/28.x.x/env-1/hook-nesting.json
+++ b/e2e/__fixtures__/28.x.x/env-1/hook-nesting.json
@@ -24,7 +24,7 @@
     "describeId": "describe_1"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "describe_1",
     "path": "vendor.maintainer",
@@ -35,7 +35,7 @@
     "operation": "assign"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "describe_1",
     "path": "vendor.lead",
@@ -46,7 +46,7 @@
     "operation": "merge"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "describe_1",
     "path": "vendor.description",
@@ -60,7 +60,7 @@
     "hookType": "beforeAll"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_1",
     "path": "vendor.description",
@@ -74,7 +74,7 @@
     "hookType": "beforeEach"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_2",
     "path": "vendor.description",
@@ -88,7 +88,7 @@
     "hookType": "afterEach"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_3",
     "path": "vendor.description",
@@ -102,7 +102,7 @@
     "hookType": "afterAll"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_4",
     "path": "vendor.description",
@@ -115,7 +115,7 @@
     "testId": "test_0"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "test_0",
     "path": [
@@ -133,7 +133,7 @@
     "testId": "test_1"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "test_1",
     "path": [
@@ -146,7 +146,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "test_1",
     "path": [
@@ -188,7 +188,7 @@
     "hookId": "hook_1"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_1.0",
     "path": "vendor.steps",
@@ -226,7 +226,7 @@
     "hookId": "hook_2"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_2.0",
     "path": "vendor.steps",
@@ -249,7 +249,7 @@
     "testId": "test_0"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "test_0.0.fn",
     "path": "vendor.steps",
@@ -262,7 +262,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "test_0.0.fn",
     "path": "vendor.steps",
@@ -285,7 +285,7 @@
     "hookId": "hook_3"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_3.0",
     "path": "vendor.steps",
@@ -328,7 +328,7 @@
     "hookId": "hook_2"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_2.1",
     "path": "vendor.steps",
@@ -351,7 +351,7 @@
     "testId": "test_1"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "test_1.0.fn",
     "path": "vendor.steps",
@@ -364,7 +364,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "test_1.0.fn",
     "path": "vendor.steps",
@@ -387,7 +387,7 @@
     "hookId": "hook_3"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_3.1",
     "path": "vendor.steps",
@@ -415,7 +415,7 @@
     "hookId": "hook_4"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_4.0",
     "path": "vendor.steps",

--- a/e2e/__fixtures__/28.x.x/env-1/test-concurrent.json
+++ b/e2e/__fixtures__/28.x.x/env-1/test-concurrent.json
@@ -68,7 +68,7 @@
     "testId": "test_0"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/test-concurrent.js",
     "targetId": "test_0.0.fn",
     "path": "test.slept",
@@ -96,7 +96,7 @@
     "testId": "test_1"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/test-concurrent.js",
     "targetId": "test_1.0.fn",
     "path": "test.slept",
@@ -124,7 +124,7 @@
     "testId": "test_2"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/test-concurrent.js",
     "targetId": "test_2.0.fn",
     "path": "test.slept",
@@ -152,7 +152,7 @@
     "testId": "test_3"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/test-concurrent.js",
     "targetId": "test_3.0.fn",
     "path": "test.slept",
@@ -180,7 +180,7 @@
     "testId": "test_4"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/test-concurrent.js",
     "targetId": "test_4.0.fn",
     "path": "test.slept",

--- a/e2e/__fixtures__/28.x.x/env-1/test-todo.json
+++ b/e2e/__fixtures__/28.x.x/env-1/test-todo.json
@@ -92,7 +92,7 @@
     "hookId": "hook_1"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/test-todo.js",
     "targetId": "hook_1.0",
     "path": "note",
@@ -115,7 +115,7 @@
     "hookId": "hook_2"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/test-todo.js",
     "targetId": "hook_2.0",
     "path": "note",
@@ -143,7 +143,7 @@
     "hookId": "hook_3"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/test-todo.js",
     "targetId": "hook_3.0",
     "path": "note",
@@ -166,7 +166,7 @@
     "hookId": "hook_4"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/test-todo.js",
     "targetId": "hook_4.0",
     "path": "note",

--- a/e2e/__fixtures__/28.x.x/env-N/duplicate-name.json
+++ b/e2e/__fixtures__/28.x.x/env-N/duplicate-name.json
@@ -133,7 +133,7 @@
     "hookId": "hook_1"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "hook_1.0",
     "path": "note",
@@ -156,7 +156,7 @@
     "hookId": "hook_2"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "hook_2.0",
     "path": "note",
@@ -189,7 +189,7 @@
     "testId": "test_0"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "test_0.0.fn",
     "path": "note",
@@ -227,7 +227,7 @@
     "testId": "test_1"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "test_1.0.fn",
     "path": "note",
@@ -270,7 +270,7 @@
     "testId": "test_1"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "test_1.1.fn",
     "path": "note",
@@ -293,7 +293,7 @@
     "hookId": "hook_3"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "hook_3.0",
     "path": "note",
@@ -341,7 +341,7 @@
     "hookId": "hook_4"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "hook_4.0",
     "path": "note",
@@ -374,7 +374,7 @@
     "testId": "test_4"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "test_4.0.fn",
     "path": "note",
@@ -412,7 +412,7 @@
     "testId": "test_5"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "test_5.0.fn",
     "path": "note",
@@ -455,7 +455,7 @@
     "testId": "test_4"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "test_4.1.fn",
     "path": "note",
@@ -478,7 +478,7 @@
     "hookId": "hook_5"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "hook_5.0",
     "path": "note",

--- a/e2e/__fixtures__/28.x.x/env-N/globalMetadata.json
+++ b/e2e/__fixtures__/28.x.x/env-N/globalMetadata.json
@@ -1,6 +1,6 @@
 [
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -9,7 +9,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -18,7 +18,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -27,7 +27,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -36,7 +36,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -45,7 +45,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -54,7 +54,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -63,7 +63,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -72,7 +72,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -81,7 +81,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -90,7 +90,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -99,7 +99,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [

--- a/e2e/__fixtures__/28.x.x/env-N/hook-nesting.json
+++ b/e2e/__fixtures__/28.x.x/env-N/hook-nesting.json
@@ -24,7 +24,7 @@
     "describeId": "describe_1"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "describe_1",
     "path": "vendor.maintainer",
@@ -35,7 +35,7 @@
     "operation": "assign"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "describe_1",
     "path": "vendor.lead",
@@ -46,7 +46,7 @@
     "operation": "merge"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "describe_1",
     "path": "vendor.description",
@@ -60,7 +60,7 @@
     "hookType": "beforeAll"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_1",
     "path": "vendor.description",
@@ -74,7 +74,7 @@
     "hookType": "beforeEach"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_2",
     "path": "vendor.description",
@@ -88,7 +88,7 @@
     "hookType": "afterEach"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_3",
     "path": "vendor.description",
@@ -102,7 +102,7 @@
     "hookType": "afterAll"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_4",
     "path": "vendor.description",
@@ -115,7 +115,7 @@
     "testId": "test_0"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "test_0",
     "path": [
@@ -133,7 +133,7 @@
     "testId": "test_1"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "test_1",
     "path": [
@@ -146,7 +146,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "test_1",
     "path": [
@@ -188,7 +188,7 @@
     "hookId": "hook_1"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_1.0",
     "path": "vendor.steps",
@@ -226,7 +226,7 @@
     "hookId": "hook_2"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_2.0",
     "path": "vendor.steps",
@@ -249,7 +249,7 @@
     "testId": "test_0"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "test_0.0.fn",
     "path": "vendor.steps",
@@ -262,7 +262,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "test_0.0.fn",
     "path": "vendor.steps",
@@ -285,7 +285,7 @@
     "hookId": "hook_3"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_3.0",
     "path": "vendor.steps",
@@ -328,7 +328,7 @@
     "hookId": "hook_2"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_2.1",
     "path": "vendor.steps",
@@ -351,7 +351,7 @@
     "testId": "test_1"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "test_1.0.fn",
     "path": "vendor.steps",
@@ -364,7 +364,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "test_1.0.fn",
     "path": "vendor.steps",
@@ -387,7 +387,7 @@
     "hookId": "hook_3"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_3.1",
     "path": "vendor.steps",
@@ -415,7 +415,7 @@
     "hookId": "hook_4"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_4.0",
     "path": "vendor.steps",

--- a/e2e/__fixtures__/28.x.x/env-N/test-concurrent.json
+++ b/e2e/__fixtures__/28.x.x/env-N/test-concurrent.json
@@ -68,7 +68,7 @@
     "testId": "test_0"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/test-concurrent.js",
     "targetId": "test_0.0.fn",
     "path": "test.slept",
@@ -96,7 +96,7 @@
     "testId": "test_1"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/test-concurrent.js",
     "targetId": "test_1.0.fn",
     "path": "test.slept",
@@ -124,7 +124,7 @@
     "testId": "test_2"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/test-concurrent.js",
     "targetId": "test_2.0.fn",
     "path": "test.slept",
@@ -152,7 +152,7 @@
     "testId": "test_3"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/test-concurrent.js",
     "targetId": "test_3.0.fn",
     "path": "test.slept",
@@ -180,7 +180,7 @@
     "testId": "test_4"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/test-concurrent.js",
     "targetId": "test_4.0.fn",
     "path": "test.slept",

--- a/e2e/__fixtures__/28.x.x/env-N/test-todo.json
+++ b/e2e/__fixtures__/28.x.x/env-N/test-todo.json
@@ -92,7 +92,7 @@
     "hookId": "hook_1"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/test-todo.js",
     "targetId": "hook_1.0",
     "path": "note",
@@ -115,7 +115,7 @@
     "hookId": "hook_2"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/test-todo.js",
     "targetId": "hook_2.0",
     "path": "note",
@@ -143,7 +143,7 @@
     "hookId": "hook_3"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/test-todo.js",
     "targetId": "hook_3.0",
     "path": "note",
@@ -166,7 +166,7 @@
     "hookId": "hook_4"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/test-todo.js",
     "targetId": "hook_4.0",
     "path": "note",

--- a/e2e/__fixtures__/29.x.x/bail-env-1/globalMetadata.json
+++ b/e2e/__fixtures__/29.x.x/bail-env-1/globalMetadata.json
@@ -1,6 +1,6 @@
 [
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [

--- a/e2e/__fixtures__/29.x.x/bail-env-N/globalMetadata.json
+++ b/e2e/__fixtures__/29.x.x/bail-env-N/globalMetadata.json
@@ -1,6 +1,6 @@
 [
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -9,7 +9,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [

--- a/e2e/__fixtures__/29.x.x/env-1/duplicate-name.json
+++ b/e2e/__fixtures__/29.x.x/env-1/duplicate-name.json
@@ -133,7 +133,7 @@
     "hookId": "hook_1"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "hook_1.0",
     "path": "note",
@@ -156,7 +156,7 @@
     "hookId": "hook_2"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "hook_2.0",
     "path": "note",
@@ -194,7 +194,7 @@
     "testId": "test_0"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "test_0.0.fn",
     "path": "note",
@@ -237,7 +237,7 @@
     "testId": "test_1"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "test_1.0.fn",
     "path": "note",
@@ -285,7 +285,7 @@
     "testId": "test_1"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "test_1.1.fn",
     "path": "note",
@@ -308,7 +308,7 @@
     "hookId": "hook_3"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "hook_3.0",
     "path": "note",
@@ -356,7 +356,7 @@
     "hookId": "hook_4"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "hook_4.0",
     "path": "note",
@@ -394,7 +394,7 @@
     "testId": "test_4"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "test_4.0.fn",
     "path": "note",
@@ -437,7 +437,7 @@
     "testId": "test_5"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "test_5.0.fn",
     "path": "note",
@@ -485,7 +485,7 @@
     "testId": "test_4"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "test_4.1.fn",
     "path": "note",
@@ -508,7 +508,7 @@
     "hookId": "hook_5"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "hook_5.0",
     "path": "note",

--- a/e2e/__fixtures__/29.x.x/env-1/globalMetadata.json
+++ b/e2e/__fixtures__/29.x.x/env-1/globalMetadata.json
@@ -1,6 +1,6 @@
 [
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -9,7 +9,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -18,7 +18,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -27,7 +27,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -36,7 +36,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -45,7 +45,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -54,7 +54,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -63,7 +63,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -72,7 +72,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -81,7 +81,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -90,7 +90,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -99,7 +99,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [

--- a/e2e/__fixtures__/29.x.x/env-1/hook-nesting.json
+++ b/e2e/__fixtures__/29.x.x/env-1/hook-nesting.json
@@ -24,7 +24,7 @@
     "describeId": "describe_1"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "describe_1",
     "path": "vendor.maintainer",
@@ -35,7 +35,7 @@
     "operation": "assign"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "describe_1",
     "path": "vendor.lead",
@@ -46,7 +46,7 @@
     "operation": "merge"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "describe_1",
     "path": "vendor.description",
@@ -60,7 +60,7 @@
     "hookType": "beforeAll"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_1",
     "path": "vendor.description",
@@ -74,7 +74,7 @@
     "hookType": "beforeEach"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_2",
     "path": "vendor.description",
@@ -88,7 +88,7 @@
     "hookType": "afterEach"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_3",
     "path": "vendor.description",
@@ -102,7 +102,7 @@
     "hookType": "afterAll"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_4",
     "path": "vendor.description",
@@ -115,7 +115,7 @@
     "testId": "test_0"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "test_0",
     "path": [
@@ -133,7 +133,7 @@
     "testId": "test_1"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "test_1",
     "path": [
@@ -146,7 +146,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "test_1",
     "path": [
@@ -188,7 +188,7 @@
     "hookId": "hook_1"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_1.0",
     "path": "vendor.steps",
@@ -231,7 +231,7 @@
     "hookId": "hook_2"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_2.0",
     "path": "vendor.steps",
@@ -254,7 +254,7 @@
     "testId": "test_0"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "test_0.0.fn",
     "path": "vendor.steps",
@@ -267,7 +267,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "test_0.0.fn",
     "path": "vendor.steps",
@@ -290,7 +290,7 @@
     "hookId": "hook_3"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_3.0",
     "path": "vendor.steps",
@@ -338,7 +338,7 @@
     "hookId": "hook_2"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_2.1",
     "path": "vendor.steps",
@@ -361,7 +361,7 @@
     "testId": "test_1"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "test_1.0.fn",
     "path": "vendor.steps",
@@ -374,7 +374,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "test_1.0.fn",
     "path": "vendor.steps",
@@ -397,7 +397,7 @@
     "hookId": "hook_3"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_3.1",
     "path": "vendor.steps",
@@ -425,7 +425,7 @@
     "hookId": "hook_4"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_4.0",
     "path": "vendor.steps",

--- a/e2e/__fixtures__/29.x.x/env-1/test-concurrent.json
+++ b/e2e/__fixtures__/29.x.x/env-1/test-concurrent.json
@@ -73,7 +73,7 @@
     "testId": "test_0"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/test-concurrent.js",
     "targetId": "test_0.0.fn",
     "path": "test.slept",
@@ -106,7 +106,7 @@
     "testId": "test_1"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/test-concurrent.js",
     "targetId": "test_1.0.fn",
     "path": "test.slept",
@@ -139,7 +139,7 @@
     "testId": "test_2"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/test-concurrent.js",
     "targetId": "test_2.0.fn",
     "path": "test.slept",
@@ -172,7 +172,7 @@
     "testId": "test_3"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/test-concurrent.js",
     "targetId": "test_3.0.fn",
     "path": "test.slept",
@@ -205,7 +205,7 @@
     "testId": "test_4"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/test-concurrent.js",
     "targetId": "test_4.0.fn",
     "path": "test.slept",

--- a/e2e/__fixtures__/29.x.x/env-1/test-todo.json
+++ b/e2e/__fixtures__/29.x.x/env-1/test-todo.json
@@ -92,7 +92,7 @@
     "hookId": "hook_1"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/test-todo.js",
     "targetId": "hook_1.0",
     "path": "note",
@@ -115,7 +115,7 @@
     "hookId": "hook_2"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/test-todo.js",
     "targetId": "hook_2.0",
     "path": "note",
@@ -143,7 +143,7 @@
     "hookId": "hook_3"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/test-todo.js",
     "targetId": "hook_3.0",
     "path": "note",
@@ -166,7 +166,7 @@
     "hookId": "hook_4"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/test-todo.js",
     "targetId": "hook_4.0",
     "path": "note",

--- a/e2e/__fixtures__/29.x.x/env-N/duplicate-name.json
+++ b/e2e/__fixtures__/29.x.x/env-N/duplicate-name.json
@@ -133,7 +133,7 @@
     "hookId": "hook_1"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "hook_1.0",
     "path": "note",
@@ -156,7 +156,7 @@
     "hookId": "hook_2"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "hook_2.0",
     "path": "note",
@@ -194,7 +194,7 @@
     "testId": "test_0"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "test_0.0.fn",
     "path": "note",
@@ -237,7 +237,7 @@
     "testId": "test_1"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "test_1.0.fn",
     "path": "note",
@@ -285,7 +285,7 @@
     "testId": "test_1"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "test_1.1.fn",
     "path": "note",
@@ -308,7 +308,7 @@
     "hookId": "hook_3"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "hook_3.0",
     "path": "note",
@@ -356,7 +356,7 @@
     "hookId": "hook_4"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "hook_4.0",
     "path": "note",
@@ -394,7 +394,7 @@
     "testId": "test_4"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "test_4.0.fn",
     "path": "note",
@@ -437,7 +437,7 @@
     "testId": "test_5"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "test_5.0.fn",
     "path": "note",
@@ -485,7 +485,7 @@
     "testId": "test_4"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "test_4.1.fn",
     "path": "note",
@@ -508,7 +508,7 @@
     "hookId": "hook_5"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/duplicate-name.js",
     "targetId": "hook_5.0",
     "path": "note",

--- a/e2e/__fixtures__/29.x.x/env-N/globalMetadata.json
+++ b/e2e/__fixtures__/29.x.x/env-N/globalMetadata.json
@@ -1,6 +1,6 @@
 [
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -9,7 +9,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -18,7 +18,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -27,7 +27,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -36,7 +36,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -45,7 +45,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -54,7 +54,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -63,7 +63,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -72,7 +72,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -81,7 +81,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -90,7 +90,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [
@@ -99,7 +99,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "targetId": "globalMetadata",
     "path": "vendor.tests",
     "value": [

--- a/e2e/__fixtures__/29.x.x/env-N/hook-nesting.json
+++ b/e2e/__fixtures__/29.x.x/env-N/hook-nesting.json
@@ -24,7 +24,7 @@
     "describeId": "describe_1"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "describe_1",
     "path": "vendor.maintainer",
@@ -35,7 +35,7 @@
     "operation": "assign"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "describe_1",
     "path": "vendor.lead",
@@ -46,7 +46,7 @@
     "operation": "merge"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "describe_1",
     "path": "vendor.description",
@@ -60,7 +60,7 @@
     "hookType": "beforeAll"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_1",
     "path": "vendor.description",
@@ -74,7 +74,7 @@
     "hookType": "beforeEach"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_2",
     "path": "vendor.description",
@@ -88,7 +88,7 @@
     "hookType": "afterEach"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_3",
     "path": "vendor.description",
@@ -102,7 +102,7 @@
     "hookType": "afterAll"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_4",
     "path": "vendor.description",
@@ -115,7 +115,7 @@
     "testId": "test_0"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "test_0",
     "path": [
@@ -133,7 +133,7 @@
     "testId": "test_1"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "test_1",
     "path": [
@@ -146,7 +146,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "test_1",
     "path": [
@@ -188,7 +188,7 @@
     "hookId": "hook_1"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_1.0",
     "path": "vendor.steps",
@@ -231,7 +231,7 @@
     "hookId": "hook_2"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_2.0",
     "path": "vendor.steps",
@@ -254,7 +254,7 @@
     "testId": "test_0"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "test_0.0.fn",
     "path": "vendor.steps",
@@ -267,7 +267,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "test_0.0.fn",
     "path": "vendor.steps",
@@ -290,7 +290,7 @@
     "hookId": "hook_3"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_3.0",
     "path": "vendor.steps",
@@ -338,7 +338,7 @@
     "hookId": "hook_2"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_2.1",
     "path": "vendor.steps",
@@ -361,7 +361,7 @@
     "testId": "test_1"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "test_1.0.fn",
     "path": "vendor.steps",
@@ -374,7 +374,7 @@
     "operation": "push"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "test_1.0.fn",
     "path": "vendor.steps",
@@ -397,7 +397,7 @@
     "hookId": "hook_3"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_3.1",
     "path": "vendor.steps",
@@ -425,7 +425,7 @@
     "hookId": "hook_4"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "targetId": "hook_4.0",
     "path": "vendor.steps",

--- a/e2e/__fixtures__/29.x.x/env-N/test-concurrent.json
+++ b/e2e/__fixtures__/29.x.x/env-N/test-concurrent.json
@@ -73,7 +73,7 @@
     "testId": "test_0"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/test-concurrent.js",
     "targetId": "test_0.0.fn",
     "path": "test.slept",
@@ -106,7 +106,7 @@
     "testId": "test_1"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/test-concurrent.js",
     "targetId": "test_1.0.fn",
     "path": "test.slept",
@@ -139,7 +139,7 @@
     "testId": "test_2"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/test-concurrent.js",
     "targetId": "test_2.0.fn",
     "path": "test.slept",
@@ -172,7 +172,7 @@
     "testId": "test_3"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/test-concurrent.js",
     "targetId": "test_3.0.fn",
     "path": "test.slept",
@@ -205,7 +205,7 @@
     "testId": "test_4"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/test-concurrent.js",
     "targetId": "test_4.0.fn",
     "path": "test.slept",

--- a/e2e/__fixtures__/29.x.x/env-N/test-todo.json
+++ b/e2e/__fixtures__/29.x.x/env-N/test-todo.json
@@ -92,7 +92,7 @@
     "hookId": "hook_1"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/test-todo.js",
     "targetId": "hook_1.0",
     "path": "note",
@@ -115,7 +115,7 @@
     "hookId": "hook_2"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/test-todo.js",
     "targetId": "hook_2.0",
     "path": "note",
@@ -143,7 +143,7 @@
     "hookId": "hook_3"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/test-todo.js",
     "targetId": "hook_3.0",
     "path": "note",
@@ -166,7 +166,7 @@
     "hookId": "hook_4"
   },
   {
-    "type": "set_metadata",
+    "type": "write_metadata",
     "testFilePath": "__tests__/default/test-todo.js",
     "targetId": "hook_4.0",
     "path": "note",

--- a/src/ipc/BatchMessage.ts
+++ b/src/ipc/BatchMessage.ts
@@ -1,8 +1,6 @@
-import type { MetadataEvent } from '../metadata';
-
 export type BatchMessage = {
-  /** The batch of messages. */
-  batch: MetadataEvent[];
+  /** The batch of stringified messages. */
+  batch: string[];
   /** Whether this is the first batch of messages. */
   first?: boolean;
   /** Whether this is the last batch of messages. */

--- a/src/ipc/IPCClient.ts
+++ b/src/ipc/IPCClient.ts
@@ -29,7 +29,7 @@ export class IPCClient {
   private readonly _serverId: string;
   private _startPromise?: Promise<void>;
   private _stopPromise?: Promise<void>;
-  private _queue: MetadataEvent[] = [];
+  private _queue: string[] = [];
   private _connection?: IPCConnection;
   private _globalMetadata: GlobalMetadata;
 
@@ -81,7 +81,7 @@ export class IPCClient {
       return;
     }
 
-    this._queue.push(event);
+    this._queue.push(JSON.stringify(event));
   }
 
   async flush(modifier?: 'first' | 'last'): Promise<void> {

--- a/src/ipc/IPCServer.ts
+++ b/src/ipc/IPCServer.ts
@@ -92,7 +92,8 @@ export class IPCServer {
   }
 
   private _onClientMessageBatch({ batch, first, last }: BatchMessage, socket: Socket) {
-    for (const event of batch) {
+    for (const rawEvent of batch) {
+      const event = JSON.parse(rawEvent);
       if (event.type !== 'add_test_file') {
         // Jest Metadata server adds new test files before we get
         // the independent confirmation from the Jest worker via IPC.

--- a/src/jest-reporter/__tests__/fallback-api.test.ts
+++ b/src/jest-reporter/__tests__/fallback-api.test.ts
@@ -6,7 +6,7 @@ import {
   MetadataEventEmitter,
   MetadataEventHandler,
   MetadataFactoryImpl,
-  SetMetadataEventEmitter,
+  WriteMetadataEventEmitter,
 } from '../../metadata';
 import { SerialSyncEmitter } from '../../utils';
 import { AssociateMetadata } from '../AssociateMetadata';
@@ -26,7 +26,7 @@ describe('Fallback API', () => {
     const emitter = new SerialSyncEmitter<MetadataEvent>('core').on('*', (event: MetadataEvent) => {
       metadataHandler.handle(event);
     }) as MetadataEventEmitter;
-    const setEmitter = new SerialSyncEmitter('set') as SetMetadataEventEmitter;
+    const setEmitter = new SerialSyncEmitter('set') as WriteMetadataEventEmitter;
     const metadataRegistry = new GlobalMetadataRegistry();
     const metadataFactory = new MetadataFactoryImpl(metadataRegistry, setEmitter);
     const globalMetadata = metadataFactory.createGlobalMetadata();

--- a/src/metadata/MetadataEventHandler.ts
+++ b/src/metadata/MetadataEventHandler.ts
@@ -20,7 +20,7 @@ import type {
   RunDescribeStartEvent,
   RunFinishEvent,
   RunStartEvent,
-  SetMetadataEvent,
+  WriteMetadataEvent,
   StartDescribeDefinitionEvent,
   TestDoneEvent,
   AddTestFileEvent,
@@ -226,7 +226,7 @@ export class MetadataEventHandler {
       test[internal.finish]();
     },
 
-    set_metadata: (event: SetMetadataEvent) => {
+    write_metadata: (event: WriteMetadataEvent) => {
       const targetId = new AggregatedIdentifier(event.testFilePath, event.targetId);
       const metadata = this._metadataRegistry.get(targetId);
 

--- a/src/metadata/__tests__/integration.test.ts
+++ b/src/metadata/__tests__/integration.test.ts
@@ -6,14 +6,14 @@ import {
   GlobalMetadataRegistry,
   MetadataEventHandler,
   MetadataFactoryImpl,
-  SetMetadataEventEmitter,
+  WriteMetadataEventEmitter,
 } from '../index';
 
 describe('metadata - integration test:', () => {
   test.each(Object.values(fixtures.metadata))(
     `e2e/__fixtures__/%s`,
     (_name: string, fixture: any[]) => {
-      const emitter: SetMetadataEventEmitter = new SerialSyncEmitter('set');
+      const emitter: WriteMetadataEventEmitter = new SerialSyncEmitter('set');
       const metadataRegistry = new GlobalMetadataRegistry();
       const metadataFactory = new MetadataFactoryImpl(metadataRegistry, emitter);
       const globalMetadata = metadataFactory.createGlobalMetadata();

--- a/src/metadata/__tests__/run-traversal.test.ts
+++ b/src/metadata/__tests__/run-traversal.test.ts
@@ -6,7 +6,7 @@ import {
   Metadata,
   MetadataEventHandler,
   MetadataFactoryImpl,
-  SetMetadataEventEmitter,
+  WriteMetadataEventEmitter,
 } from '../index';
 
 describe('file metadata traversal:', () => {
@@ -15,7 +15,7 @@ describe('file metadata traversal:', () => {
   });
 
   test.each(lastFixtures)(`fixtures/%s`, (_name: string, fixture: any[]) => {
-    const emitter: SetMetadataEventEmitter = new SerialSyncEmitter('set');
+    const emitter: WriteMetadataEventEmitter = new SerialSyncEmitter('set');
     const metadataRegistry = new GlobalMetadataRegistry();
     const metadataFactory = new MetadataFactoryImpl(metadataRegistry, emitter);
     const globalMetadata = metadataFactory.createGlobalMetadata();

--- a/src/metadata/containers/BaseMetadata.ts
+++ b/src/metadata/containers/BaseMetadata.ts
@@ -41,7 +41,7 @@ export abstract class BaseMetadata implements Metadata {
     this.#set(path, value);
 
     this[symbols.context].emitter.emit({
-      type: 'set_metadata',
+      type: 'write_metadata',
       testFilePath: this[symbols.id].testFilePath,
       targetId: this[symbols.id].identifier,
       path,
@@ -69,7 +69,7 @@ export abstract class BaseMetadata implements Metadata {
     this.#set(path, array);
 
     this[symbols.context].emitter.emit({
-      type: 'set_metadata',
+      type: 'write_metadata',
       testFilePath: this[symbols.id].testFilePath,
       targetId: this[symbols.id].identifier,
       path,
@@ -89,7 +89,7 @@ export abstract class BaseMetadata implements Metadata {
     }
 
     this[symbols.context].emitter.emit({
-      type: 'set_metadata',
+      type: 'write_metadata',
       testFilePath: this[symbols.id].testFilePath,
       targetId: this[symbols.id].identifier,
       path,
@@ -109,7 +109,7 @@ export abstract class BaseMetadata implements Metadata {
     }
 
     this[symbols.context].emitter.emit({
-      type: 'set_metadata',
+      type: 'write_metadata',
       testFilePath: this[symbols.id].testFilePath,
       targetId: this[symbols.id].identifier,
       path,

--- a/src/metadata/containers/MetadataContext.ts
+++ b/src/metadata/containers/MetadataContext.ts
@@ -1,11 +1,11 @@
 import type { MetadataChecker } from '../checker';
 import type { MetadataFactory } from '../factory';
 import type { MetadataSelectorFactory } from '../selector';
-import type { SetMetadataEventEmitter } from '../types';
+import type { WriteMetadataEventEmitter } from '../types';
 
 export type MetadataContext = {
   checker: MetadataChecker;
-  emitter: SetMetadataEventEmitter;
+  emitter: WriteMetadataEventEmitter;
   factory: MetadataFactory;
   createMetadataSelector: MetadataSelectorFactory;
 };

--- a/src/metadata/events/MetadataEvent.ts
+++ b/src/metadata/events/MetadataEvent.ts
@@ -9,7 +9,6 @@ import type { RunDescribeFinishEvent } from './RunDescribeFinishEvent';
 import type { RunDescribeStartEvent } from './RunDescribeStartEvent';
 import type { RunFinishEvent } from './RunFinishEvent';
 import type { RunStartEvent } from './RunStartEvent';
-import type { SetMetadataEvent } from './SetMetadataEvent';
 import type { SetupEvent } from './SetupEvent';
 import type { StartDescribeDefinitionEvent } from './StartDescribeDefinitionEvent';
 import type { TestDoneEvent } from './TestDoneEvent';
@@ -21,6 +20,7 @@ import type { TestSkipEvent } from './TestSkipEvent';
 import type { TestStartedEvent } from './TestStartedEvent';
 import type { TestStartEvent } from './TestStartEvent';
 import type { TestTodoEvent } from './TestTodoEvent';
+import type { WriteMetadataEvent } from './WriteMetadataEvent';
 
 export type MetadataEvent =
   | SetupEvent
@@ -34,7 +34,7 @@ export type MetadataEvent =
   | RunDescribeStartEvent
   | RunFinishEvent
   | RunStartEvent
-  | SetMetadataEvent
+  | WriteMetadataEvent
   | StartDescribeDefinitionEvent
   | TestDoneEvent
   | AddTestFileEvent

--- a/src/metadata/events/WriteMetadataEvent.ts
+++ b/src/metadata/events/WriteMetadataEvent.ts
@@ -1,5 +1,5 @@
-export type SetMetadataEvent = {
-  type: 'set_metadata';
+export type WriteMetadataEvent = {
+  type: 'write_metadata';
   testFilePath?: string;
   targetId: string; // instance ID
   path?: string | readonly string[];

--- a/src/metadata/events/index.ts
+++ b/src/metadata/events/index.ts
@@ -14,7 +14,7 @@ export { RunDescribeFinishEvent } from './RunDescribeFinishEvent';
 export { RunDescribeStartEvent } from './RunDescribeStartEvent';
 export { RunFinishEvent } from './RunFinishEvent';
 export { RunStartEvent } from './RunStartEvent';
-export { SetMetadataEvent } from './SetMetadataEvent';
+export { WriteMetadataEvent } from './WriteMetadataEvent';
 export { StartDescribeDefinitionEvent } from './StartDescribeDefinitionEvent';
 export { TestDoneEvent } from './TestDoneEvent';
 export { TestFnFailureEvent } from './TestFnFailureEvent';

--- a/src/metadata/factory/MetadataFactoryImpl.ts
+++ b/src/metadata/factory/MetadataFactoryImpl.ts
@@ -16,7 +16,7 @@ import { AggregatedIdentifier } from '../ids';
 import type { FileMetadataRegistry } from '../registry';
 import { MetadataSelectorImpl } from '../selector';
 import * as symbols from '../symbols';
-import type { HookType, SetMetadataEventEmitter } from '../types';
+import type { HookType, WriteMetadataEventEmitter } from '../types';
 
 import type { MetadataFactory } from './MetadataFactory';
 
@@ -36,7 +36,7 @@ export class MetadataFactoryImpl implements MetadataFactory {
 
   constructor(
     private readonly metadataRegistry: FileMetadataRegistry<unknown>,
-    private readonly emitter: SetMetadataEventEmitter,
+    private readonly emitter: WriteMetadataEventEmitter,
   ) {
     this.#context = {
       factory: this,

--- a/src/metadata/types/SetMetadataEventEmitter.ts
+++ b/src/metadata/types/SetMetadataEventEmitter.ts
@@ -1,4 +1,0 @@
-import type { Emitter } from '../../types';
-import type { SetMetadataEvent } from '../events';
-
-export type SetMetadataEventEmitter = Emitter<SetMetadataEvent>;

--- a/src/metadata/types/WriteMetadataEventEmitter.ts
+++ b/src/metadata/types/WriteMetadataEventEmitter.ts
@@ -1,0 +1,4 @@
+import type { Emitter } from '../../types';
+import type { WriteMetadataEvent } from '../events';
+
+export type WriteMetadataEventEmitter = Emitter<WriteMetadataEvent>;

--- a/src/metadata/types/index.ts
+++ b/src/metadata/types/index.ts
@@ -3,4 +3,4 @@ export * from './HookType';
 export * from './Metadata';
 export * from './MetadataEventEmitter';
 export * from './ReadonlyMetadataEventEmitter';
-export * from './SetMetadataEventEmitter';
+export * from './WriteMetadataEventEmitter';

--- a/src/realms/BaseRealm.ts
+++ b/src/realms/BaseRealm.ts
@@ -8,8 +8,8 @@ import {
   MetadataEventEmitter,
   MetadataEventHandler,
   MetadataFactoryImpl,
-  SetMetadataEvent,
-  SetMetadataEventEmitter,
+  WriteMetadataEvent,
+  WriteMetadataEventEmitter,
 } from '../metadata';
 
 import { AggregatedEmitter, SerialSyncEmitter } from '../utils';
@@ -21,7 +21,9 @@ export abstract class BaseRealm {
       this.metadataHandler.handle(event);
     },
   ) as MetadataEventEmitter;
-  readonly setEmitter = new SerialSyncEmitter<SetMetadataEvent>('set') as SetMetadataEventEmitter;
+  readonly setEmitter = new SerialSyncEmitter<WriteMetadataEvent>(
+    'set',
+  ) as WriteMetadataEventEmitter;
   readonly events = new AggregatedEmitter<MetadataEvent>('events').add(this.coreEmitter);
 
   readonly metadataRegistry = new GlobalMetadataRegistry();


### PR DESCRIPTION
Fixes issue spotted while developing [jest-allure2-reporter](https://github.com/wix-incubator/jest-allure2-reporter).

This project strives to optimise things and suffers from this good intent.
When writing user metadata, we enqueue the changes while keeping direct references to the objects in question.
So, if the events live long enough in the IPC message batch, they might get mutated inadvertently.

The solution is to serialize the payload immediately to stay away from these dangerous situations.
They're damn hard to debug, so little performance decrease is worth it.
UPD: benchmarks don't show any noticeable decrease (still ¹⁄₃ ms per test).

P.S. On top of this, I renamed "set metadata" events to "write metadata", because it confuses when you're observing logs: there are multiple operations: set, assign, merge, push, so it's better not to confuse set and set.