### PR TITLE
fix: default and named exports

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,6 @@
 coverage/**
 dist/**
 e2e/**
+package-e2e/**
 *.js
+*.mjs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,16 +37,27 @@ jobs:
       - name: Build package for E2E
         run: npm run build:e2e
 
-      - uses: bahmutov/npm-install@v1
+      - name: Packaging tests - Install
+        uses: bahmutov/npm-install@v1
+        with:
+          useLockFile: false
+          working-directory: package-e2e
+
+      - name: Packaging tests - Run
+        run: npm test
+        working-directory: package-e2e
+
+      - name: E2E tests - Install
+        uses: bahmutov/npm-install@v1
         with:
           useLockFile: false
           working-directory: e2e
 
-      - name: Record fixtures
+      - name: E2E tests - Record fixtures
         run: npm run build
         working-directory: e2e
 
-      - name: Assert no Git changes
+      - name: E2E tests - Assert no Git changes
         run: git diff --exit-code e2e/__fixtures__
 
       - name: Upload artifacts
@@ -73,7 +84,8 @@ jobs:
         with:
           node-version-file: '.nvmrc'
 
-      - uses: bahmutov/npm-install@v1
+      - name: Install dependencies
+        uses: bahmutov/npm-install@v1
         with:
           useLockFile: false
 
@@ -84,12 +96,12 @@ jobs:
         with:
           node-version-file: 'e2e/.nvmrc'
 
-      - name: Update fixtures
+      - name: E2E tests - Update fixtures
         run: npm run update-fixtures
         env:
           JEST_VERSION: ${{ matrix.jest }}
 
-      - name: Assert no Git changes
+      - name: E2E tests - Assert no Git changes
         run: git diff --exit-code e2e/__fixtures__
 
       - name: Upload artifacts

--- a/debug.js
+++ b/debug.js
@@ -1,2 +1,1 @@
-/* Jest 27 fallback */
 module.exports = require('./dist/debug');

--- a/debug.mjs
+++ b/debug.mjs
@@ -1,0 +1,1 @@
+export * from './dist/debug.js';

--- a/e2e/reporters/recorder.js
+++ b/e2e/reporters/recorder.js
@@ -4,7 +4,7 @@ const path = require('path');
 const { satisfies: semverSatisfies } = require('semver');
 const { version: jestVersion } = require('jest/package.json');
 const debugUtils = require('jest-metadata/debug');
-const { JestMetadataReporter } = require('jest-metadata/reporter');
+const JestMetadataReporter = require('jest-metadata/reporter');
 
 const PRESET = process.env.PRESET || '';
 const cwd = process.cwd();

--- a/environment-decorator.js
+++ b/environment-decorator.js
@@ -1,2 +1,1 @@
-/* Jest 27 fallback */
-module.exports = require('./dist/environment-decorator');
+module.exports = require('./dist/environment-decorator').default;

--- a/environment-decorator.mjs
+++ b/environment-decorator.mjs
@@ -1,0 +1,5 @@
+import environmentDecorator from './dist/environment-decorator.js';
+
+const { default: WithMetadata } = environmentDecorator;
+
+export default WithMetadata;

--- a/environment-jsdom.js
+++ b/environment-jsdom.js
@@ -1,2 +1,1 @@
-/* Jest 27 fallback */
-module.exports = require('./dist/environment-jsdom');
+module.exports = require('./dist/environment-jsdom').default;

--- a/environment-jsdom.mjs
+++ b/environment-jsdom.mjs
@@ -1,0 +1,5 @@
+import environmentJsdom from './dist/environment-jsdom.js';
+
+const { default: TestEnvironment } = environmentJsdom;
+
+export default TestEnvironment;

--- a/environment-listener.js
+++ b/environment-listener.js
@@ -1,2 +1,1 @@
-/* Jest 27 fallback */
-module.exports = require('./dist/environment-listener');
+module.exports = require('./dist/environment-listener').default;

--- a/environment-listener.mjs
+++ b/environment-listener.mjs
@@ -1,0 +1,5 @@
+import environmentListener from './dist/environment-listener.js';
+
+const { default: listener } = environmentListener;
+
+export default listener;

--- a/environment-node.js
+++ b/environment-node.js
@@ -1,2 +1,1 @@
-/* Jest 27 fallback */
-module.exports = require('./dist/environment-node');
+module.exports = require('./dist/environment-node').default;

--- a/environment-node.mjs
+++ b/environment-node.mjs
@@ -1,0 +1,5 @@
+import environmentNode from './dist/environment-node.js';
+
+const { default: TestEnvironment } = environmentNode;
+
+export default TestEnvironment;

--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/index');

--- a/index.mjs
+++ b/index.mjs
@@ -1,0 +1,1 @@
+export * from './dist/index.js';

--- a/package-e2e/.npmrc
+++ b/package-e2e/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/package-e2e/package.json
+++ b/package-e2e/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@jest-metadata/package-e2e",
+  "private": true,
+  "version": "1.0.0",
+  "description": "",
+  "scripts": {
+    "test": "node test.cjs && node test.mjs && tsc",
+    "test:cjs": "node test.cjs",
+    "test:mjs": "node test.mjs",
+    "test:ts": "tsc"
+  },
+  "dependencies": {
+    "jest-metadata": "file:../package.tar.gz"
+  }
+}

--- a/package-e2e/test.cjs
+++ b/package-e2e/test.cjs
@@ -1,0 +1,30 @@
+const assert = require('assert');
+
+const { metadata, state, $Set, $Push, $Merge, $Assign, $Unshift } = require('jest-metadata');
+assert(typeof metadata === 'object', 'jest-metadata should export `metadata` object');
+assert(typeof state === 'object', 'jest-metadata should export `state` object');
+assert(typeof $Set === 'function', 'jest-metadata should export $Set function as a named export');
+assert(typeof $Push === 'function', 'jest-metadata should export $Push function as a named export');
+assert(typeof $Merge === 'function', 'jest-metadata should export $Merge function as a named export');
+assert(typeof $Assign === 'function', 'jest-metadata should export $Assign function as a named export');
+assert(typeof $Unshift === 'function', 'jest-metadata should export $Unshift function as a named export');
+
+const { events } = require('jest-metadata/debug');
+assert(typeof events === 'object', 'jest-metadata/debug should export `events` object');
+
+const environmentListener = require('jest-metadata/environment-listener');
+assert(typeof environmentListener === 'function', 'jest-metadata/environment-listener should export a class as its default export');
+
+const JsdomTestEnvironment = require('jest-metadata/environment-jsdom');
+assert(isClass(JsdomTestEnvironment), 'jest-metadata/environment-jsdom should export a class as its default export');
+
+const NodeTestEnvironment = require('jest-metadata/environment-node');
+assert(isClass(NodeTestEnvironment), 'jest-metadata/environment-node should export a class as its default export');
+
+const JestMetadataReporter = require('jest-metadata/reporter');
+assert(isClass(JestMetadataReporter), 'jest-metadata/reporter should export a class as its default export');
+assert(typeof JestMetadataReporter.query === 'object', 'jest-metadata/reporter class should export .query helper');
+
+function isClass(obj) {
+  return typeof obj === 'function' && /^class\s/.test(Function.prototype.toString.call(obj));
+}

--- a/package-e2e/test.mjs
+++ b/package-e2e/test.mjs
@@ -1,0 +1,30 @@
+import assert from 'assert';
+import { $Set, $Push, $Merge, $Assign, $Unshift, state, metadata } from 'jest-metadata';
+import { events } from 'jest-metadata/debug';
+import JsdomTestEnvironment from 'jest-metadata/environment-jsdom';
+import NodeTestEnvironment from 'jest-metadata/environment-node';
+import environmentListener from 'jest-metadata/environment-listener';
+import JestMetadataReporter from 'jest-metadata/reporter';
+
+assert(typeof metadata === 'object', 'jest-metadata should export `metadata` object');
+assert(typeof state === 'object', 'jest-metadata should export `state` object');
+assert(typeof $Set === 'function', 'jest-metadata should export `$Set` function as a named export');
+assert(typeof $Push === 'function', 'jest-metadata should export `$Push` function as a named export');
+assert(typeof $Merge === 'function', 'jest-metadata should export `$Merge` function as a named export');
+assert(typeof $Assign === 'function', 'jest-metadata should export `$Assign` function as a named export');
+assert(typeof $Unshift === 'function', 'jest-metadata should export `$Unshift` function as a named export');
+
+assert(typeof events === 'object', 'jest-metadata/debug should export `events` object');
+
+assert(typeof environmentListener === 'function', 'jest-metadata/environment-listener should export a function as its default export');
+
+assert(isClass(JsdomTestEnvironment), 'jest-metadata/environment-jsdom should export a class as its default export');
+
+assert(isClass(NodeTestEnvironment), 'jest-metadata/environment-node should export a class as its default export');
+
+assert(isClass(JestMetadataReporter), 'jest-metadata/reporter should export a class as its default export');
+assert(typeof JestMetadataReporter.query === 'object', 'jest-metadata/reporter class should export .query helper');
+
+function isClass(obj) {
+  return typeof obj === 'function' && /^class\s/.test(Function.prototype.toString.call(obj));
+}

--- a/package-e2e/test.ts
+++ b/package-e2e/test.ts
@@ -1,0 +1,34 @@
+import { $Set, $Push, $Merge, $Assign, $Unshift, state, metadata } from 'jest-metadata';
+import { events } from 'jest-metadata/debug';
+import type { GlobalMetadata, Metadata } from 'jest-metadata';
+import JestMetadataReporter from 'jest-metadata/reporter';
+import JsdomTestEnvironment from 'jest-metadata/environment-jsdom';
+import NodeTestEnvironment from 'jest-metadata/environment-node';
+import environmentListener from 'jest-metadata/environment-listener';
+
+function assertType<T>(_actual: T): void {
+  // no-op
+}
+
+assertType<GlobalMetadata>(state);
+assertType<Metadata>(metadata);
+assertType<Function>($Set);
+assertType<Function>($Push);
+assertType<Function>($Merge);
+assertType<Function>($Assign);
+assertType<Function>($Unshift);
+
+assertType<object>(events);
+
+assertType<Function>(JestMetadataReporter);
+assertType<Function>(JestMetadataReporter.query.globalMetadata);
+assertType<Function>(JestMetadataReporter.query.test);
+assertType<Function>(JestMetadataReporter.query.filePath);
+assertType<Function>(JestMetadataReporter.query.testResult);
+assertType<Function>(JestMetadataReporter.query.testCaseResult);
+
+assertType<Function>(JsdomTestEnvironment);
+
+assertType<Function>(NodeTestEnvironment);
+
+assertType<Function>(environmentListener);

--- a/package-e2e/tsconfig.json
+++ b/package-e2e/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "noEmit": true
+  },
+  "files": [
+    "test.ts"
+  ],
+}

--- a/package.json
+++ b/package.json
@@ -10,44 +10,45 @@
     "src",
     "dist",
     "*.js",
+    "*.mjs",
     "!**/__utils__",
     "!**/__tests__",
     "!**/*.test.*"
   ],
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "require": "./dist/index.js",
+      "import": "./index.mjs",
+      "require": "./index.js",
       "types": "./dist/index.d.ts"
     },
     "./debug": {
-      "import": "./dist/debug.js",
-      "require": "./dist/debug.js",
+      "import": "./debug.mjs",
+      "require": "./debug.js",
       "types": "./dist/debug.d.ts"
     },
     "./environment-decorator": {
-      "import": "./dist/environment-decorator.js",
-      "require": "./dist/environment-decorator.js",
+      "import": "./environment-decorator.mjs",
+      "require": "./environment-decorator.js",
       "types": "./dist/environment-decorator.d.ts"
     },
     "./environment-listener": {
-      "import": "./dist/environment-listener.js",
-      "require": "./dist/environment-listener.js",
+      "import": "./environment-listener.mjs",
+      "require": "./environment-listener.js",
       "types": "./dist/environment-listener.d.ts"
     },
     "./environment-jsdom": {
-      "import": "./dist/environment-jsdom.js",
-      "require": "./dist/environment-jsdom.js",
+      "import": "./environment-jsdom.mjs",
+      "require": "./environment-jsdom.js",
       "types": "./dist/environment-jsdom.d.ts"
     },
     "./environment-node": {
-      "import": "./dist/environment-node.js",
-      "require": "./dist/environment-node.js",
+      "import": "./environment-node.mjs",
+      "require": "./environment-node.js",
       "types": "./dist/environment-node.d.ts"
     },
     "./reporter": {
-      "import": "./dist/reporter.js",
-      "require": "./dist/reporter.js",
+      "import": "./reporter.mjs",
+      "require": "./reporter.js",
       "types": "./dist/reporter.d.ts"
     },
     "./package.json": "./package.json"

--- a/reporter.js
+++ b/reporter.js
@@ -1,2 +1,1 @@
-/* Jest 27 fallback */
-module.exports = require('./dist/reporter');
+module.exports = require('./dist/reporter').default;

--- a/reporter.mjs
+++ b/reporter.mjs
@@ -1,0 +1,5 @@
+import reporter from './dist/reporter.js';
+
+const { default: JestMetadataReporter } = reporter;
+
+export default JestMetadataReporter;

--- a/src/environment-decorator.ts
+++ b/src/environment-decorator.ts
@@ -2,6 +2,8 @@ import type { JestEnvironment } from '@jest/environment';
 import WithEmitter from 'jest-environment-emit';
 import listener from './environment-listener';
 
-export const WithMetadata = <E extends JestEnvironment = JestEnvironment>(
+const WithMetadata = <E extends JestEnvironment = JestEnvironment>(
   JestEnvironmentClass: new (...args: any[]) => E,
 ) => WithEmitter<E>(JestEnvironmentClass, listener, 'WithMetadata');
+
+export default WithMetadata;

--- a/src/environment-jsdom.ts
+++ b/src/environment-jsdom.ts
@@ -1,5 +1,4 @@
 import JestEnvironmentJsdom from 'jest-environment-jsdom';
-import { WithMetadata } from './environment-decorator';
+import WithMetadata from './environment-decorator';
 
-export const TestEnvironment = WithMetadata(JestEnvironmentJsdom);
-export default TestEnvironment;
+export default WithMetadata(JestEnvironmentJsdom);

--- a/src/environment-node.ts
+++ b/src/environment-node.ts
@@ -1,5 +1,4 @@
 import JestEnvironmentNode from 'jest-environment-node';
-import { WithMetadata } from './environment-decorator';
+import WithMetadata from './environment-decorator';
 
-export const TestEnvironment = WithMetadata(JestEnvironmentNode);
-export default TestEnvironment;
+export default WithMetadata(JestEnvironmentNode);

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -17,12 +17,12 @@ const realm = unknownRealm as ParentProcessRealm;
 
 detectDuplicateRealms(true);
 
-export const query = realm.query;
-
 /**
  * @implements {import('@jest/reporters').Reporter}
  */
-export class JestMetadataReporter implements Reporter {
+export default class JestMetadataReporter implements Reporter {
+  static readonly query = realm.query;
+
   constructor(_globalConfig: Config.GlobalConfig) {
     if (realm.type !== 'parent_process') {
       throw new JestMetadataError(`JestMetadataReporter can be used only in the parent process`);
@@ -79,5 +79,3 @@ export class JestMetadataReporter implements Reporter {
     return realm.reporterServer.onRunComplete();
   }
 }
-
-export default JestMetadataReporter;


### PR DESCRIPTION
Fixes #67.

See the updated correct way to import the module.

* In ESM:

```js
import assert from 'assert';
import { state, metadata } from 'jest-metadata';
import { events } from 'jest-metadata/debug';
import environmentListener from 'jest-metadata/environment-listener';
import JsdomTestEnvironment from 'jest-metadata/environment-jsdom';
import NodeTestEnvironment from 'jest-metadata/environment-node';
import JestMetadataReporter from 'jest-metadata/reporter';
```

* In CJS:

```js
const { metadata, state } = require('jest-metadata');
const { events } = require('jest-metadata/debug');
const environmentListener = require('jest-metadata/environment-listener');
const JsdomTestEnvironment = require('jest-metadata/environment-jsdom');
const NodeTestEnvironment = require('jest-metadata/environment-node');
const JestMetadataReporter = require('jest-metadata/reporter');
```

**Breaking changes** are that you cannot use named exports/imports in these modules:

* `jest-metadata/environment-listener`
* `jest-metadata/environment-jsdom`
* `jest-metadata/environment-node`
* `jest-metadata/reporter`