### PR TITLE
fix: add_hook and add_test handling

### DIFF
--- a/e2e/__fixtures__/27.x.x/env-1/hook-nesting.json
+++ b/e2e/__fixtures__/27.x.x/env-1/hook-nesting.json
@@ -19,6 +19,14 @@
     "hookType": "beforeEach"
   },
   {
+    "type": "write_metadata",
+    "testFilePath": "__tests__/default/hook-nesting.js",
+    "targetId": "describe_0",
+    "path": "vendor.filename",
+    "value": "hook-nesting.js",
+    "operation": "set"
+  },
+  {
     "type": "start_describe_definition",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "describeId": "describe_1"

--- a/e2e/__fixtures__/27.x.x/env-N/hook-nesting.json
+++ b/e2e/__fixtures__/27.x.x/env-N/hook-nesting.json
@@ -19,6 +19,14 @@
     "hookType": "beforeEach"
   },
   {
+    "type": "write_metadata",
+    "testFilePath": "__tests__/default/hook-nesting.js",
+    "targetId": "describe_0",
+    "path": "vendor.filename",
+    "value": "hook-nesting.js",
+    "operation": "set"
+  },
+  {
     "type": "start_describe_definition",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "describeId": "describe_1"

--- a/e2e/__fixtures__/28.x.x/env-1/hook-nesting.json
+++ b/e2e/__fixtures__/28.x.x/env-1/hook-nesting.json
@@ -19,6 +19,14 @@
     "hookType": "beforeEach"
   },
   {
+    "type": "write_metadata",
+    "testFilePath": "__tests__/default/hook-nesting.js",
+    "targetId": "describe_0",
+    "path": "vendor.filename",
+    "value": "hook-nesting.js",
+    "operation": "set"
+  },
+  {
     "type": "start_describe_definition",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "describeId": "describe_1"

--- a/e2e/__fixtures__/28.x.x/env-N/hook-nesting.json
+++ b/e2e/__fixtures__/28.x.x/env-N/hook-nesting.json
@@ -19,6 +19,14 @@
     "hookType": "beforeEach"
   },
   {
+    "type": "write_metadata",
+    "testFilePath": "__tests__/default/hook-nesting.js",
+    "targetId": "describe_0",
+    "path": "vendor.filename",
+    "value": "hook-nesting.js",
+    "operation": "set"
+  },
+  {
     "type": "start_describe_definition",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "describeId": "describe_1"

--- a/e2e/__fixtures__/29.x.x/env-1/hook-nesting.json
+++ b/e2e/__fixtures__/29.x.x/env-1/hook-nesting.json
@@ -19,6 +19,14 @@
     "hookType": "beforeEach"
   },
   {
+    "type": "write_metadata",
+    "testFilePath": "__tests__/default/hook-nesting.js",
+    "targetId": "describe_0",
+    "path": "vendor.filename",
+    "value": "hook-nesting.js",
+    "operation": "set"
+  },
+  {
     "type": "start_describe_definition",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "describeId": "describe_1"

--- a/e2e/__fixtures__/29.x.x/env-N/hook-nesting.json
+++ b/e2e/__fixtures__/29.x.x/env-N/hook-nesting.json
@@ -19,6 +19,14 @@
     "hookType": "beforeEach"
   },
   {
+    "type": "write_metadata",
+    "testFilePath": "__tests__/default/hook-nesting.js",
+    "targetId": "describe_0",
+    "path": "vendor.filename",
+    "value": "hook-nesting.js",
+    "operation": "set"
+  },
+  {
     "type": "start_describe_definition",
     "testFilePath": "__tests__/default/hook-nesting.js",
     "describeId": "describe_1"

--- a/e2e/__tests__/default/hook-nesting.js
+++ b/e2e/__tests__/default/hook-nesting.js
@@ -21,12 +21,17 @@ const $Flaky = () => $Unshift(['vendor', 'labels'], 'flaky');
 
 const step = (text) => metadata.push('vendor.steps', [{ text, startedAt: now }]);
 
+// Should be attached to ROOT_DESCRIBE_BLOCK
+metadata.set('vendor.filename', 'hook-nesting.js');
+
 $Maintainer('Jane Smith', 'jane.smith@example.com');
 $Lead('Samantha Jones', 'samantha.jones@example.com');
 $Author('John Doe', 'john.doe@example.com');
 $Author('Impostor', 'impostor@example.fake');
-$Description('This is a sample test suite.');
 describe('Login flow', () => {
+  // ↑ Should be attached to `describe` block
+  metadata.set('vendor.description', 'This is a sample test suite.');
+
   $Description('Prepare the environment');
   beforeAll(() => {
     step('Open the browser');

--- a/src/environment-listener.ts
+++ b/src/environment-listener.ts
@@ -50,6 +50,10 @@ const listener: EnvironmentListenerFn = (context) => {
     realm.environmentHandler.handleTestEvent(event, state);
   };
 
+  const backToDescribe = () => {
+    realm.metadataHandler.backToDescribe(testFilePath);
+  };
+
   const flushHandler = () => realm.ipc.flush();
 
   context.testEvents
@@ -79,6 +83,8 @@ const listener: EnvironmentListenerFn = (context) => {
     .on('finish_describe_definition', testEventHandler, Number.MAX_SAFE_INTEGER)
     .on('add_hook', testEventHandler, -1)
     .on('add_test', testEventHandler, -1)
+    .on('add_hook', backToDescribe, Number.MAX_SAFE_INTEGER)
+    .on('add_test', backToDescribe, Number.MAX_SAFE_INTEGER)
     .on('run_start', testEventHandler, -1)
     .on('run_start', flushHandler, Number.MAX_SAFE_INTEGER)
     .on('run_describe_start', testEventHandler, -1)

--- a/src/metadata/MetadataEventHandler.ts
+++ b/src/metadata/MetadataEventHandler.ts
@@ -243,4 +243,14 @@ export class MetadataEventHandler {
     const handler = this._handlers[event.type] as (event: MetadataEvent) => void;
     handler(event);
   };
+
+  backToDescribe = (testFilePath: string): void => {
+    const file = this._metadata.getTestFileMetadata(testFilePath);
+    const currentDescribeBlock = file.current.describeBlock;
+    if (!currentDescribeBlock) {
+      throw new JestMetadataError('No current describe block');
+    }
+
+    file[internal.currentMetadata] = currentDescribeBlock;
+  };
 }

--- a/src/metadata/__tests__/__snapshots__/integration.test.ts.snap
+++ b/src/metadata/__tests__/__snapshots__/integration.test.ts.snap
@@ -563,6 +563,7 @@ global_metadata : id = "globalMetadata"
 object "TestFileMetadata" as tests_default_hook_nesting_js #def
 object "DescribeBlockMetadata" as tests_default_hook_nesting_js_describe_0 #ded
 tests_default_hook_nesting_js_describe_0 : id = "describe_0"
+tests_default_hook_nesting_js_describe_0 : data = {\\n  "vendor": {\\n    "filename": "hook-nesting.js"\\n  }\\n}
 object "HookDefinitionMetadata" as tests_default_hook_nesting_js_hook_0 #fdd
 tests_default_hook_nesting_js_hook_0 : id = "hook_0"
 tests_default_hook_nesting_js_hook_0 : hookType = "beforeEach"
@@ -1557,6 +1558,7 @@ global_metadata : id = "globalMetadata"
 object "TestFileMetadata" as tests_default_hook_nesting_js #def
 object "DescribeBlockMetadata" as tests_default_hook_nesting_js_describe_0 #ded
 tests_default_hook_nesting_js_describe_0 : id = "describe_0"
+tests_default_hook_nesting_js_describe_0 : data = {\\n  "vendor": {\\n    "filename": "hook-nesting.js"\\n  }\\n}
 object "HookDefinitionMetadata" as tests_default_hook_nesting_js_hook_0 #fdd
 tests_default_hook_nesting_js_hook_0 : id = "hook_0"
 tests_default_hook_nesting_js_hook_0 : hookType = "beforeEach"
@@ -2531,6 +2533,7 @@ global_metadata : id = "globalMetadata"
 object "TestFileMetadata" as tests_default_hook_nesting_js #def
 object "DescribeBlockMetadata" as tests_default_hook_nesting_js_describe_0 #ded
 tests_default_hook_nesting_js_describe_0 : id = "describe_0"
+tests_default_hook_nesting_js_describe_0 : data = {\\n  "vendor": {\\n    "filename": "hook-nesting.js"\\n  }\\n}
 object "HookDefinitionMetadata" as tests_default_hook_nesting_js_hook_0 #fdd
 tests_default_hook_nesting_js_hook_0 : id = "hook_0"
 tests_default_hook_nesting_js_hook_0 : hookType = "beforeEach"


### PR DESCRIPTION
I noticed that in an flat test file:

```
// my.test.js
metadata.set('key', 'value');
```

for some weird reason gets assigned to a hook, and not to ROOT_DESCRIBE_BLOCK, like I'd expect initially.

It turned out that my handling of `add_hook` and `add_test` was slightly incorrect – they should not permanently set `currentMetadata` to a test/hook definition.

So, what I'm doing now is to set a special listener which fires last and re-focuses the current metadata to the current describe block. This should help.