### PR TITLE
fix: increase error resilience

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
   "dependencies": {
     "bunyamin": "^1.5.2",
     "funpermaproxy": "^1.1.0",
-    "jest-environment-emit": "^1.0.6",
+    "jest-environment-emit": "^1.0.8",
     "lodash.merge": "^4.6.2",
     "lodash.snakecase": "^4.1.1",
     "node-ipc": "9.2.1",


### PR DESCRIPTION
JestMetadataReporter should not throw exceptions. Otherwise, Jest's own execution will become unpredictable.

This is why all the fragile methods are guarded now with try-catch.