### PR TITLE
fix: improve duplicate jest-metadata detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,11 +7,12 @@
   "files": [
     ".idea/icon.svg",
     "README.md",
+    "scripts/postinstall.js",
     "src",
     "dist",
-    "*.js",
-    "*.d.ts",
-    "*.mjs",
+    "./*.js",
+    "./*.d.ts",
+    "./*.mjs",
     "!**/__utils__",
     "!**/__tests__",
     "!**/*.test.*"
@@ -60,6 +61,7 @@
   "scripts": {
     "prepare": "husky install || true",
     "prepack": "tsc",
+    "postinstall": "node scripts/postinstall.js",
     "build": "tsc",
     "build:e2e": "tsc && nyc instrument --in-place dist && npm pack && mv jest-metadata-*.tgz package.tar.gz",
     "docs": "typedoc",

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs');
+const path = require('node:path');
+const process = require('node:process');
+
+const instances = [];
+
+for (let cwd = process.cwd(); cwd !== path.dirname(cwd); cwd = path.dirname(cwd)) {
+  const anotherInstance = path.join(cwd, 'node_modules', 'jest-metadata');
+  if (fs.existsSync(anotherInstance)) {
+    instances.push(anotherInstance);
+  }
+}
+
+if (instances.length > 1) {
+  process.exitCode = 1;
+
+  console.error('\x1b[31m%s\x1b[0m', [
+    '[jest-metadata] postinstall script failed!',
+    'More than one instance of jest-metadata has been installed:',
+    ...instances.map((dir) => `- ${dir}`),
+    'Please flatten your package-lock.json or yarn.lock file to resolve this issue.',
+  ].join('\n'));
+}


### PR DESCRIPTION
It turns out that it is still problematic to detect early issues when `jest-metadata` does not get flattened via npm or yarn.

Unflattened `jest-metadata` often means that the multiple erroneously raised instances collect scattered pieces of metadata and do not get the entire picture, which defeats the purpose of this library.

Someday, we might come up with a better solution and allow multiple instances to work independently but not today.