### PR TITLE
fix: fallback mode per file

### DIFF
--- a/src/utils/jestUtils.ts
+++ b/src/utils/jestUtils.ts
@@ -6,6 +6,6 @@ export function isSingleWorker(config: Config.GlobalConfig) {
 
 export function isInsideIDE(config: Config.GlobalConfig) {
   const isSingleReporter = config.reporters && config.reporters.length === 1;
-  const singleReporter = isSingleReporter ? config.reporters?.[0]?.[0] ?? '' : '';
+  const singleReporter = isSingleReporter ? (config.reporters?.[0]?.[0] ?? '') : '';
   return /jest-intellij/i.test(singleReporter);
 }


### PR DESCRIPTION
Fixes an edge case spotted on CI.

To reproduce on affected versions:

* Run test project with multiple workers
* Some test files should initialize properly, some others must fail while initializing the test environment
* Spectate weird errors like `Metadata (undefined) is not an instance of TestFileMetadata` from this place:

```
if (!(metadata instanceof Klass)) {
  throw new TypeError(`Metadata (${metadata?.id}) is not an instance of ${klassName}`);
}
```